### PR TITLE
feat(tun): add sing-box TUN mode for system-wide proxy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize all text files to LF on commit, auto-convert on checkout.
+* text=auto eol=lf
+
+# Keep Windows-specific scripts as CRLF.
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files — don't touch.
+*.png binary
+*.jpg binary
+*.ico binary

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,11 @@ dist-ssr/
 *.local
 src-tauri/target/
 src-tauri/gen/
-src-tauri/binaries/aether
-src-tauri/binaries/aether.exe
-src-tauri/binaries/*.tar.gz
-src-tauri/binaries/*.zip
-src-tauri/binaries/SHA256SUMS.txt
+src-tauri/binaries/*
+!src-tauri/binaries/fetch-aether.sh
+!src-tauri/binaries/fetch-aether.ps1
+!src-tauri/binaries/fetch-singbox.sh
+!src-tauri/binaries/fetch-singbox.ps1
 # Aether writes its provisioned device identity (private keys, access
 # tokens) here when run with binaries/ as its cwd (e.g. manual testing) —
 # must never be committed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,15 +7,17 @@
 
                             Preamble
 
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
+the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -24,34 +26,44 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -60,7 +72,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU Affero General Public License.
+  "This License" refers to version 3 of the GNU General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -537,45 +549,35 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
+  13. Use with the GNU Affero General Public License.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
+under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
+Program specifies that a certain numbered version of the GNU General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
+GNU General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
+versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -633,29 +635,40 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published
-    by the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
+    You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
+For more information on this, and how to apply and follow the GNU GPL, see
 <https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Aether-GUI
 
 [![Release](https://img.shields.io/github/v/release/MatinSenPai/Aether-GUI?sort=semver)](https://github.com/MatinSenPai/Aether-GUI/releases)
-[![License: AGPL v3](https://img.shields.io/github/license/MatinSenPai/Aether-GUI)](LICENSE)
+[![License: GPL v3](https://img.shields.io/github/license/MatinSenPai/Aether-GUI)](LICENSE)
 ![Platform](https://img.shields.io/badge/platform-Windows-0078D6)
 ![Tauri](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
@@ -26,10 +26,12 @@ This project does not reimplement any of Aether's tunneling logic. It drives the
   - **IP Version**: IPv4, IPv6, or both
   - **MASQUE Transport**: HTTP/3 (QUIC — fastest handshake) or HTTP/2 (TCP — looks like ordinary HTTPS, works where UDP is blocked or throttled)
   - **Quick reconnect**: remember the last working gateway and re-test it first, skipping the full scan when it still works
+  - **System-wide TUN**: route all system traffic through the tunnel (requires Administrator, bundles sing-box + wintun)
   
   Each option has an explanation on hover.
 - **Live progress** — while Aether searches for a working route, the GUI shows real elapsed time and, once Aether reports its own scan budget, an actual percentage and progress bar — not just a spinner.
 - **Automatic reconnect** — if the tunnel drops unexpectedly mid-session (observed occasionally with WARP-in-WARP, but handled the same way for every protocol), the GUI retries automatically with backoff, shown as a visible "Reconnecting… (attempt N of 3)" rather than silently dying or dumping you back to a bare error. A user-requested disconnect is never retried.
+- **System-wide TUN mode** — optional toggle that starts a [sing-box](https://github.com/SagerNet/sing-box) TUN interface on top of Aether's SOCKS5 proxy, routing all system traffic through the tunnel without per-app proxy configuration. Requires Administrator privileges.
 
 ## Installing
 
@@ -53,15 +55,34 @@ Windows x64 only for now — see [Building from source](#building-from-source) f
    npm install
    ```
 
-3. **Fetch the Aether binary**
+3. **Fetch the Aether and sing-box binaries**
 
-   Aether-GUI bundles the real `aether` binary from [CluvexStudio/Aether releases](https://github.com/CluvexStudio/Aether/releases) rather than building it — this repo only ships the GUI. Fetch and checksum-verify it for your platform:
+   Aether-GUI bundles two external binaries rather than building them — this repo only ships the GUI.
 
    ```sh
    ./src-tauri/binaries/fetch-aether.sh
+   ./src-tauri/binaries/fetch-singbox.sh
    ```
 
-   This script covers Linux and macOS directly. On Windows, download the matching `aether-windows-*.zip` from the [Aether releases page](https://github.com/CluvexStudio/Aether/releases) yourself, verify it against the published `SHA256SUMS.txt`, and extract `aether.exe` into `src-tauri/binaries/`.
+   `fetch-aether.sh` downloads the Aether binary from [CluvexStudio/Aether releases](https://github.com/CluvexStudio/Aether/releases). On native Windows, use the PowerShell equivalent:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File src-tauri/binaries/fetch-aether.ps1
+   ```
+
+   `fetch-singbox.sh` downloads [sing-box](https://github.com/SagerNet/sing-box) and `wintun.dll` for the TUN mode feature. On native Windows (without Git Bash/MSYS2), use the PowerShell equivalent:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File src-tauri/binaries/fetch-singbox.ps1
+   ```
+
+   Or use the combined npm script:
+
+   ```sh
+   npm run fetch:binaries
+   ```
+
+   All downloaded binaries are gitignored — they are only needed locally for building.
 
 4. **Run in development mode**
 
@@ -80,9 +101,9 @@ Windows x64 only for now — see [Building from source](#building-from-source) f
 ## How it works
 
 - **Frontend**: React 19 + Tailwind v4, state managed with Zustand, animated with [Motion](https://motion.dev/) — all talking to the Rust backend over Tauri's IPC. Deliberately lightweight: the ambient background is two compositor-only CSS gradient orbs, and every looping animation freezes while the window is unfocused, so the app costs next to nothing sitting in the background.
-- **Backend**: Rust, using [`portable-pty`](https://docs.rs/portable-pty) to spawn the real `aether` binary (v1.2.0) in a genuine pseudo-terminal. Your chosen profile — protocol, scan mode, IP version, MASQUE transport (HTTP/3 or HTTP/2), quick reconnect — is passed as CLI flags/environment up front, so Aether's interactive prompts normally never appear; a background thread still watches the output and can answer any prompt that does, while forwarding every line live to the GUI's log panel.
+- **Backend**: Rust, using [`portable-pty`](https://docs.rs/portable-pty) to spawn the real `aether` binary (v1.2.0) in a genuine pseudo-terminal. When TUN mode is enabled, a second process ([sing-box](https://github.com/SagerNet/sing-box) v1.13.14) is spawned to create a system-wide TUN interface that routes all traffic through Aether's SOCKS5 proxy. Your chosen profile — protocol, scan mode, IP version, MASQUE transport (HTTP/3 or HTTP/2), quick reconnect — is passed as CLI flags/environment up front, so Aether's interactive prompts normally never appear; a background thread still watches the output and can answer any prompt that does, while forwarding every line live to the GUI's log panel.
 - **Ground truth for "connected"**: the GUI doesn't trust Aether's log wording alone (that's fragile across releases) — it treats a successful TCP connection to the local SOCKS5 port (`127.0.0.1:1819`) as the actual proof the tunnel is up.
-- **State machine**: `Idle → Launching → Connecting → Connected`, with `Reconnecting` and `Error` as the two ways a connection attempt can end up needing your attention — `Reconnecting` retries automatically (with backoff, capped at 3 attempts), `Error` is the final word once retries are exhausted or something isn't retriable (e.g. the binary itself is missing).
+- **State machine**: `Idle → Launching → Connecting → Connected` (or `Connected → Tunneling` when TUN mode is enabled), with `Reconnecting` and `Error` as the two ways a connection attempt can end up needing your attention — `Reconnecting` retries automatically (with backoff, capped at 3 attempts), `Error` is the final word once retries are exhausted or something isn't retriable (e.g. the binary itself is missing).
 
 ## About Aether
 
@@ -90,4 +111,4 @@ Windows x64 only for now — see [Building from source](#building-from-source) f
 
 ## License
 
-[GNU Affero General Public License v3.0](LICENSE).
+[GNU General Public License v3.0](LICENSE).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "fetch:binaries": "bash src-tauri/binaries/fetch-aether.sh && bash src-tauri/binaries/fetch-singbox.sh"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "aether-gui"
 version = "0.4.0"
 dependencies = [
+ "embed-resource",
  "portable-pty",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+embed-resource = "3"
 
 [dependencies]
 tauri = { version = "2", features = [] }
@@ -16,4 +17,4 @@ portable-pty = "0.8"
 thiserror = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging", "Win32_UI_Shell"] }

--- a/src-tauri/app.manifest
+++ b/src-tauri/app.manifest
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="com.cluvexstudio.aethergui"
+    version="0.4.0.0"
+    processorArchitecture="*"
+  />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!-- requireAdministrator: always shows UAC prompt at launch.
+             This is required for sing-box TUN mode (creates a virtual
+             network adapter), and harmless for non-TUN usage. -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 / 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/src-tauri/app.rc
+++ b/src-tauri/app.rc
@@ -1,0 +1,1 @@
+1 RT_MANIFEST "app.manifest"

--- a/src-tauri/binaries/fetch-aether.ps1
+++ b/src-tauri/binaries/fetch-aether.ps1
@@ -1,0 +1,44 @@
+# Downloads the pinned Aether release binary for Windows into
+# src-tauri/binaries/, verified against its published SHA256SUMS.txt.
+# Run this before `tauri dev` / `tauri build` (wire into CI for each target).
+$ErrorActionPreference = "Stop"
+
+$AetherVersion = "v1.2.0"
+$Repo          = "CluvexStudio/Aether"
+$DestDir       = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$Asset    = "aether-windows-x86_64.zip"
+$Url      = "https://github.com/$Repo/releases/download/$AetherVersion/$Asset"
+$SumsUrl  = "https://github.com/$Repo/releases/download/$AetherVersion/SHA256SUMS.txt"
+$TmpDir   = Join-Path $DestDir "_tmp_aether"
+
+Write-Host "Downloading Aether $AetherVersion for Windows..."
+Invoke-WebRequest -Uri $Url -OutFile (Join-Path $DestDir $Asset) -UseBasicParsing
+
+Write-Host "Downloading SHA256 checksums..."
+$SumsContent = (Invoke-WebRequest -Uri $SumsUrl -UseBasicParsing).Content
+
+Write-Host "Verifying checksum..."
+$Expected = ($SumsContent -split "`n" | Where-Object { $_ -match $Asset } | Select-Object -First 1) -replace "\s+.*", ""
+$Hash = (Get-FileHash (Join-Path $DestDir $Asset) -Algorithm SHA256).Hash.ToLower()
+if ($Hash -ne $Expected.ToLower()) {
+    Remove-Item (Join-Path $DestDir $Asset) -Force -ErrorAction SilentlyContinue
+    Write-Error "Checksum verification failed for $Asset`n  Expected: $Expected`n  Got:      $Hash"
+}
+
+Write-Host "Extracting Aether..."
+Expand-Archive -Path (Join-Path $DestDir $Asset) -DestinationPath $TmpDir -Force
+
+$AetherExe = Get-ChildItem -Path $TmpDir -Recurse -Filter "aether.exe" | Select-Object -First 1
+if ($AetherExe) {
+    Copy-Item $AetherExe.FullName (Join-Path $DestDir "aether.exe") -Force
+    Write-Host "aether.exe ready"
+} else {
+    Write-Error "aether.exe not found in archive"
+}
+
+# Cleanup
+Remove-Item (Join-Path $DestDir $Asset) -Force -ErrorAction SilentlyContinue
+Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host "Aether binary ready at $DestDir\aether.exe"

--- a/src-tauri/binaries/fetch-singbox.ps1
+++ b/src-tauri/binaries/fetch-singbox.ps1
@@ -1,0 +1,76 @@
+# Downloads the pinned sing-box release binary and wintun.dll for Windows
+# into src-tauri/binaries/.
+# Run this before `tauri dev` / `tauri build` (wire into CI for each target).
+$ErrorActionPreference = "Stop"
+
+$SingboxVersion = "1.13.14"
+$WintunVersion  = "0.14.1"
+$DestDir        = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$Archive   = "sing-box-$SingboxVersion-windows-amd64.zip"
+$Url       = "https://github.com/SagerNet/sing-box/releases/download/v$SingboxVersion/$Archive"
+$TmpDir    = Join-Path $DestDir "_tmp_singbox"
+
+Write-Host "Downloading sing-box $SingboxVersion for windows-amd64..."
+Invoke-WebRequest -Uri $Url -OutFile (Join-Path $DestDir $Archive) -UseBasicParsing
+
+Write-Host "Extracting sing-box..."
+Expand-Archive -Path (Join-Path $DestDir $Archive) -DestinationPath $TmpDir -Force
+
+# Copy sing-box.exe
+$SbExe = Get-ChildItem -Path $TmpDir -Recurse -Filter "sing-box.exe" | Select-Object -First 1
+if ($SbExe) {
+    Copy-Item $SbExe.FullName (Join-Path $DestDir "sing-box.exe") -Force
+    Write-Host "sing-box.exe ready"
+} else {
+    Write-Error "sing-box.exe not found in archive"
+}
+
+# Copy libcronet.dll (Chromium network stack for QUIC/HTTP3 support)
+$CronetDll = Get-ChildItem -Path $TmpDir -Recurse -Filter "libcronet.dll" | Select-Object -First 1
+if ($CronetDll) {
+    Copy-Item $CronetDll.FullName (Join-Path $DestDir "libcronet.dll") -Force
+    Write-Host "libcronet.dll ready"
+}
+
+# Copy wintun.dll if present in the archive
+$WintunDll = Get-ChildItem -Path $TmpDir -Recurse -Filter "wintun.dll" | Select-Object -First 1
+if ($WintunDll) {
+    Copy-Item $WintunDll.FullName (Join-Path $DestDir "wintun.dll") -Force
+    Write-Host "wintun.dll extracted from sing-box archive"
+}
+
+# Download wintun.dll from wintun.net if not present
+if (-not (Test-Path (Join-Path $DestDir "wintun.dll"))) {
+    Write-Host "Downloading wintun $WintunVersion..."
+    $WintunArchive = "wintun-$WintunVersion.zip"
+    $WintunUrl     = "https://www.wintun.net/builds/$WintunArchive"
+    Invoke-WebRequest -Uri $WintunUrl -OutFile (Join-Path $DestDir $WintunArchive) -UseBasicParsing
+
+    $WintunTmp = Join-Path $DestDir "_tmp_wintun"
+    Expand-Archive -Path (Join-Path $DestDir $WintunArchive) -DestinationPath $WintunTmp -Force
+
+    $WintunDll = Get-ChildItem -Path $WintunTmp -Recurse -Filter "wintun.dll" | Where-Object {
+        $_.DirectoryName -match "amd64"
+    } | Select-Object -First 1
+
+    if (-not $WintunDll) {
+        $WintunDll = Get-ChildItem -Path $WintunTmp -Recurse -Filter "wintun.dll" | Select-Object -First 1
+    }
+
+    if ($WintunDll) {
+        Copy-Item $WintunDll.FullName (Join-Path $DestDir "wintun.dll") -Force
+        Write-Host "wintun.dll ready"
+    } else {
+        Write-Warning "Could not find wintun.dll in archive"
+    }
+
+    Remove-Item (Join-Path $DestDir $WintunArchive) -Force -ErrorAction SilentlyContinue
+    Remove-Item $WintunTmp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# Cleanup
+Remove-Item (Join-Path $DestDir $Archive) -Force -ErrorAction SilentlyContinue
+Remove-Item $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host "All binaries ready at $DestDir"

--- a/src-tauri/binaries/fetch-singbox.sh
+++ b/src-tauri/binaries/fetch-singbox.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Downloads the pinned sing-box release binary and wintun.dll for the
+# current platform into src-tauri/binaries/.
+# Run this before `tauri dev` / `tauri build` (wire into CI for each target).
+set -euo pipefail
+
+SINGBOX_VERSION="1.13.14"
+WINTUN_VERSION="0.14.1"
+DEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)   PLATFORM="linux-amd64"  ;;
+  Linux-aarch64)  PLATFORM="linux-arm64"  ;;
+  Darwin-x86_64)  PLATFORM="darwin-amd64" ;;
+  Darwin-arm64)   PLATFORM="darwin-arm64" ;;
+  MINGW*-*-x86_64|MSYS*-*-x86_64|CYGWIN*-*-x86_64)
+                  PLATFORM="windows-amd64" ;;
+  *)
+    echo "Unsupported platform: $(uname -s)-$(uname -m)" >&2
+    echo "For native Windows, use: powershell -ExecutionPolicy Bypass -File fetch-singbox.ps1" >&2
+    exit 1
+    ;;
+esac
+
+ARCHIVE="sing-box-${SINGBOX_VERSION}-${PLATFORM}.zip"
+URL="https://github.com/SagerNet/sing-box/releases/download/v${SINGBOX_VERSION}/${ARCHIVE}"
+SUMS_URL="https://github.com/SagerNet/sing-box/releases/download/v${SINGBOX_VERSION}/sing-box-${SINGBOX_VERSION}-linux-amd64.tar.gz.sha256sum"
+
+cd "$DEST_DIR"
+
+echo "Downloading sing-box ${SINGBOX_VERSION} for ${PLATFORM}..."
+curl -sL -o "$ARCHIVE" "$URL"
+
+EXTRACT_DIR="sing-box-${SINGBOX_VERSION}-${PLATFORM}"
+
+echo "Extracting sing-box..."
+unzip -o -j "$ARCHIVE" "${EXTRACT_DIR}/sing-box" 2>/dev/null || \
+  unzip -o -j "$ARCHIVE" "sing-box"
+
+if [[ "$PLATFORM" == *"windows"* ]]; then
+  # libcronet.dll is the Chromium network stack used for QUIC/HTTP3.
+  unzip -o -j "$ARCHIVE" "${EXTRACT_DIR}/libcronet.dll" 2>/dev/null || \
+    unzip -o -j "$ARCHIVE" "libcronet.dll" 2>/dev/null || true
+  # wintun.dll is the TUN driver used on Windows.
+  unzip -o -j "$ARCHIVE" "${EXTRACT_DIR}/wintun.dll" 2>/dev/null || \
+    unzip -o -j "$ARCHIVE" "wintun.dll" 2>/dev/null || true
+fi
+
+rm -f "$ARCHIVE"
+
+# On Windows, also download wintun.dll from wintun.net if not already present.
+if [[ "$PLATFORM" == *"windows"* ]]; then
+  if [[ ! -f wintun.dll ]]; then
+    echo "Downloading wintun ${WINTUN_VERSION}..."
+    WINTUN_ARCHIVE="wintun-${WINTUN_VERSION}.zip"
+    curl -sL -o "$WINTUN_ARCHIVE" "https://www.wintun.net/builds/${WINTUN_ARCHIVE}"
+    unzip -o -j "$WINTUN_ARCHIVE" "wintun/bin/amd64/wintun.dll" 2>/dev/null || \
+      unzip -o -j "$WINTUN_ARCHIVE" "wintun.dll" 2>/dev/null || true
+    rm -f "$WINTUN_ARCHIVE"
+    if [[ ! -f wintun.dll ]]; then
+      echo "Warning: could not extract wintun.dll from archive" >&2
+    fi
+  fi
+fi
+
+chmod +x sing-box
+echo "sing-box binary ready at $DEST_DIR/sing-box"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,10 @@
 fn main() {
+    // Embed the Windows application manifest so the exe requests admin
+    // elevation (required for sing-box TUN mode).
+    #[cfg(windows)]
+    {
+        let _ = embed_resource::compile("app.rc", &["app.manifest"]);
+    }
+
     tauri_build::build()
 }

--- a/src-tauri/src/aether/mod.rs
+++ b/src-tauri/src/aether/mod.rs
@@ -6,6 +6,7 @@ pub mod status;
 
 use crate::error::AetherError;
 use crate::events::{now_millis, LogEvent, LOG_EVENT, STATUS_EVENT};
+use crate::singbox;
 use crate::state::ConnectionState;
 use profiles::ConnectionProfile;
 use pty::PtySession;
@@ -19,6 +20,7 @@ pub struct AetherManager {
     session: Option<PtySession>,
     state: ConnectionState,
     user_requested_stop: bool,
+    enable_tun: bool,
     /// Consecutive auto-retry attempts for the current connection lineage.
     /// Reset to 0 on a fresh user-initiated connect, on reaching Connected
     /// (a proven-working connection earns a full retry budget for whatever
@@ -32,6 +34,7 @@ impl AetherManager {
             session: None,
             state: ConnectionState::Idle,
             user_requested_stop: false,
+            enable_tun: false,
             retry_count: 0,
         }
     }
@@ -74,13 +77,16 @@ pub fn start_connect(
     app: AppHandle,
     manager: Arc<Mutex<AetherManager>>,
     profile_override: Option<ConnectionProfile>,
+    enable_tun: bool,
+    singbox: Arc<Mutex<singbox::SingboxManager>>,
 ) -> Result<(), AetherError> {
     // Resolve everything fallible that doesn't touch AetherManager's state
     // first, so that once we transition to Launching below, the only
     // remaining failure mode is pty::spawn itself — which is handled
     // explicitly inside spawn_and_monitor rather than ever leaving the
     // state machine stuck in Launching with no process behind it.
-    let profile = profile_override.unwrap_or_else(|| profiles::load(&app));
+    let mut profile = profile_override.unwrap_or_else(|| profiles::load(&app));
+    profile.tun_enabled = enable_tun;
     let binary = resolve_binary(&app)?;
     let data_dir = app_data_dir(&app);
     std::fs::create_dir_all(&data_dir).map_err(|e| AetherError::Internal(e.to_string()))?;
@@ -99,13 +105,14 @@ pub fn start_connect(
             return Err(AetherError::PortInUse(status::SOCKS_PORT));
         }
         mgr.state = ConnectionState::Launching;
+        mgr.enable_tun = enable_tun;
         // A fresh user-initiated connect always gets a full retry budget,
         // independent of whatever happened on a previous, unrelated attempt.
         mgr.retry_count = 0;
     }
     let _ = app.emit(STATUS_EVENT, &ConnectionState::Launching);
 
-    spawn_and_monitor(app, manager, binary, data_dir, profile)
+    spawn_and_monitor(app, manager, binary, data_dir, profile, singbox)
 }
 
 /// Spawns the PTY session and the log-forwarding + monitor threads. Shared
@@ -118,6 +125,7 @@ fn spawn_and_monitor(
     binary: PathBuf,
     data_dir: PathBuf,
     profile: ConnectionProfile,
+    singbox: Arc<Mutex<singbox::SingboxManager>>,
 ) -> Result<(), AetherError> {
     let (log_tx, log_rx) = mpsc::channel::<LogEvent>();
     let session_or_err = pty::spawn(&binary, &data_dir, profile.clone(), log_tx);
@@ -160,7 +168,7 @@ fn spawn_and_monitor(
         let manager = Arc::clone(&manager);
         let binary = binary.clone();
         let data_dir = data_dir.clone();
-        std::thread::spawn(move || monitor_connect(app, manager, binary, data_dir, profile));
+        std::thread::spawn(move || monitor_connect(app, manager, binary, data_dir, profile, singbox));
     }
 
     Ok(())
@@ -182,6 +190,7 @@ fn handle_unexpected_failure(
     profile: ConnectionProfile,
     failure_message: String,
     phase: &'static str,
+    singbox: Arc<Mutex<singbox::SingboxManager>>,
 ) {
     let attempt = {
         let mut mgr = manager.lock().unwrap();
@@ -226,7 +235,7 @@ fn handle_unexpected_failure(
         set_state_and_emit(&app, &manager, ConnectionState::Launching);
         // spawn_and_monitor already lands its own failure in Error/retry —
         // nothing further to do with its Result here.
-        let _ = spawn_and_monitor(app, manager, binary, data_dir, profile);
+        let _ = spawn_and_monitor(app, manager, binary, data_dir, profile, singbox);
     });
 }
 
@@ -236,6 +245,7 @@ fn monitor_connect(
     binary: PathBuf,
     data_dir: PathBuf,
     profile: ConnectionProfile,
+    singbox: Arc<Mutex<singbox::SingboxManager>>,
 ) {
     let deadline = Instant::now() + status::CONNECT_TIMEOUT;
     let mut announced_connecting = false;
@@ -258,6 +268,7 @@ fn monitor_connect(
                 profile,
                 format!("Aether exited before connecting ({exit})"),
                 "connecting",
+                singbox,
             );
             return;
         }
@@ -275,9 +286,52 @@ fn monitor_connect(
         }
 
         if status::port_is_live() {
+            let socks_addr = format!("127.0.0.1:{}", status::SOCKS_PORT);
+            let connected_at_ms = now_millis();
+            let enable_tun = mgr.enable_tun;
+
+            // If TUN is requested, start sing-box and transition to Tunneling.
+            if enable_tun {
+                // Release the Aether manager lock before acquiring the singbox lock.
+                let new_state = ConnectionState::Connected {
+                    socks_addr: socks_addr.clone(),
+                    connected_at_ms,
+                };
+                mgr.state = new_state.clone();
+                mgr.retry_count = 0;
+                drop(mgr);
+                let _ = app.emit(STATUS_EVENT, &new_state);
+                profiles::save(&app, &profile);
+
+                // Start sing-box TUN tunnel.
+                // Reap any orphaned sing-box first (e.g. from a previous crash
+                // or manual kill that left the TUN adapter lingering).
+                singbox::reap_orphan(&data_dir);
+                match singbox::start_tunnel(app.clone(), singbox.clone(), status::SOCKS_PORT) {
+                    Ok(()) => {
+                        // Tunneling state will be emitted by start_tunnel's monitor thread.
+                        // Now monitor the Aether connection for drops.
+                        monitor_connected(app, manager, binary, data_dir, profile, singbox);
+                    }
+                    Err(e) => {
+                        // sing-box failed to start — Aether is still connected, so report
+                        // the tunnel error but keep Aether running.
+                        let _ = app.emit(
+                            STATUS_EVENT,
+                            &ConnectionState::Error {
+                                message: format!("Tunnel failed: {e}"),
+                                phase: "tunnel".into(),
+                            },
+                        );
+                    }
+                }
+                return;
+            }
+
+            // No TUN — just normal Connected state.
             let new_state = ConnectionState::Connected {
-                socks_addr: format!("127.0.0.1:{}", status::SOCKS_PORT),
-                connected_at_ms: now_millis(),
+                socks_addr,
+                connected_at_ms,
             };
             mgr.state = new_state.clone();
             // Proven working — a future drop earns a fresh full retry budget
@@ -288,7 +342,7 @@ fn monitor_connect(
             // Only persisted as "last successful" once actually proven to
             // work, never on a mere attempt (see profiles::save's doc-comment).
             profiles::save(&app, &profile);
-            monitor_connected(app, manager, binary, data_dir, profile);
+            monitor_connected(app, manager, binary, data_dir, profile, singbox);
             return;
         }
 
@@ -306,6 +360,7 @@ fn monitor_connect(
                 profile,
                 "Timed out waiting for Aether to find a working route".into(),
                 "connecting",
+                singbox,
             );
             return;
         }
@@ -320,6 +375,7 @@ fn monitor_connected(
     binary: PathBuf,
     data_dir: PathBuf,
     profile: ConnectionProfile,
+    singbox: Arc<Mutex<singbox::SingboxManager>>,
 ) {
     loop {
         std::thread::sleep(Duration::from_millis(500));
@@ -330,6 +386,8 @@ fn monitor_connected(
         if let Some(exit) = mgr.session.as_mut().and_then(|s| s.try_wait()) {
             mgr.session = None;
             drop(mgr);
+            // Stop sing-box if it was running.
+            singbox::stop_tunnel(&app, &singbox);
             handle_unexpected_failure(
                 app,
                 manager,
@@ -338,13 +396,17 @@ fn monitor_connected(
                 profile,
                 format!("Lost connection unexpectedly ({exit})"),
                 "connected",
+                singbox,
             );
             return;
         }
     }
 }
 
-pub fn request_disconnect(app: &AppHandle, manager: &Arc<Mutex<AetherManager>>) -> Result<(), AetherError> {
+pub fn request_disconnect(app: &AppHandle, manager: &Arc<Mutex<AetherManager>>, singbox: &Arc<Mutex<singbox::SingboxManager>>) -> Result<(), AetherError> {
+    // Stop sing-box first if it's running.
+    singbox::stop_tunnel(app, singbox);
+
     let had_session = {
         let mut mgr = manager.lock().unwrap();
         // Reconnecting has no live session (the old one already exited; the
@@ -402,7 +464,20 @@ pub fn request_disconnect(app: &AppHandle, manager: &Arc<Mutex<AetherManager>>) 
 /// Called from `RunEvent::Exit` — the app is quitting regardless, so this
 /// blocks briefly rather than spawning a thread, and skips emitting events
 /// nobody is left to receive.
-pub fn shutdown_blocking(manager: &Arc<Mutex<AetherManager>>, data_dir: &Path) {
+pub fn shutdown_blocking(manager: &Arc<Mutex<AetherManager>>, singbox: &Arc<Mutex<singbox::SingboxManager>>, data_dir: &Path) {
+    // Stop sing-box first.
+    {
+        let mut sb = singbox.lock().unwrap();
+        if let Some(proc) = sb.process.as_mut() {
+            proc.kill();
+        }
+        sb.process = None;
+        sb.active = false;
+        sb.config_path = None;
+    }
+    let _ = std::fs::remove_file(data_dir.join("singbox.pid"));
+
+    // Then stop Aether.
     let mut mgr = manager.lock().unwrap();
     if let Some(session) = mgr.session.as_mut() {
         session.send_ctrl_c();

--- a/src-tauri/src/aether/orphan.rs
+++ b/src-tauri/src/aether/orphan.rs
@@ -49,8 +49,11 @@ fn kill_pid(pid: u32) {
 
 #[cfg(windows)]
 fn is_alive(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
     std::process::Command::new("tasklist")
         .args(["/FI", &format!("PID eq {pid}")])
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
         .unwrap_or(false)
@@ -58,7 +61,10 @@ fn is_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 fn kill_pid(pid: u32) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
     let _ = std::process::Command::new("taskkill")
         .args(["/PID", &pid.to_string(), "/F"])
+        .creation_flags(CREATE_NO_WINDOW)
         .status();
 }

--- a/src-tauri/src/aether/profiles.rs
+++ b/src-tauri/src/aether/profiles.rs
@@ -84,6 +84,9 @@ pub struct ConnectionProfile {
     /// new interactive "MASQUE transport" prompt in both directions.
     #[serde(default)]
     pub masque_http2: bool,
+    /// Persist the user's TUN toggle across app restarts.
+    #[serde(default)]
+    pub tun_enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -130,6 +133,7 @@ impl Default for ConnectionProfile {
             ip_version: IpVersion::V4,
             quick_reconnect: true,
             masque_http2: false,
+            tun_enabled: false,
         }
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8,13 +8,14 @@ pub fn connect(
     app: AppHandle,
     state: State<AppState>,
     profile_override: Option<ConnectionProfile>,
+    enable_tun: Option<bool>,
 ) -> Result<(), AetherError> {
-    aether::start_connect(app, state.manager.clone(), profile_override)
+    aether::start_connect(app, state.manager.clone(), profile_override, enable_tun.unwrap_or(false), state.singbox.clone())
 }
 
 #[tauri::command]
 pub fn disconnect(app: AppHandle, state: State<AppState>) -> Result<(), AetherError> {
-    aether::request_disconnect(&app, &state.manager)
+    aether::request_disconnect(&app, &state.manager, &state.singbox)
 }
 
 #[tauri::command]
@@ -31,4 +32,9 @@ pub fn get_default_profile(app: AppHandle) -> ConnectionProfile {
 pub fn set_default_profile(app: AppHandle, profile: ConnectionProfile) -> Result<(), AetherError> {
     aether::profiles::save(&app, &profile);
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_tun_status(state: State<AppState>) -> bool {
+    state.singbox.lock().unwrap().is_active()
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -14,6 +14,12 @@ pub enum AetherError {
     NotConnected,
     #[error("internal error: {0}")]
     Internal(String),
+    #[error("sing-box binary not found at {0}")]
+    SingboxBinaryMissing(String),
+    #[error("sing-box is already running")]
+    SingboxAlreadyRunning,
+    #[error("failed to write sing-box config: {0}")]
+    SingboxConfigFailed(String),
 }
 
 // Tauri v2 command errors must be Serialize; Aether-GUI has no need to

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,22 +5,58 @@ mod commands;
 mod error;
 mod events;
 mod focus;
+mod singbox;
 mod state;
 
 use state::AppState;
 use tauri::Manager;
 
+#[cfg(windows)]
+fn is_admin() -> bool {
+    std::process::Command::new("net")
+        .args(["session"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn relaunch_as_admin() {
+    use std::os::windows::ffi::OsStrExt;
+    let exe = std::env::current_exe().expect("failed to get exe path");
+    let mut exe_wide: Vec<u16> = exe.as_os_str().encode_wide().collect();
+    exe_wide.push(0);
+    let verb: Vec<u16> = "runas\0".encode_utf16().collect();
+    unsafe {
+        windows_sys::Win32::UI::Shell::ShellExecuteW(
+            std::ptr::null_mut(),
+            verb.as_ptr(),
+            exe_wide.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
+        );
+    }
+    std::process::exit(0);
+}
+
 fn main() {
+    #[cfg(windows)]
+    if !is_admin() {
+        relaunch_as_admin();
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::default().build())
         .manage(AppState::default())
         .setup(|app| {
             let data_dir = app.handle().path().app_data_dir()?;
             std::fs::create_dir_all(&data_dir)?;
-            // Reap any Aether process left running from a prior crash before
-            // the user can click Connect and spawn a second one onto the
+            // Reap any Aether or sing-box process left running from a prior crash
+            // before the user can click Connect and spawn a second one onto the
             // same port.
             aether::orphan::reap_orphan(&data_dir);
+            singbox::reap_orphan(&data_dir);
             focus::spawn_watcher(app.handle().clone());
             Ok(())
         })
@@ -30,6 +66,7 @@ fn main() {
             commands::get_status,
             commands::get_default_profile,
             commands::set_default_profile,
+            commands::get_tun_status,
         ])
         .build(tauri::generate_context!())
         .expect("error building tauri application")
@@ -40,7 +77,7 @@ fn main() {
                     .path()
                     .app_data_dir()
                     .unwrap_or_else(|_| std::env::temp_dir());
-                aether::shutdown_blocking(&state.manager, &data_dir);
+                aether::shutdown_blocking(&state.manager, &state.singbox, &data_dir);
             }
         });
 }

--- a/src-tauri/src/singbox/config.rs
+++ b/src-tauri/src/singbox/config.rs
@@ -1,0 +1,166 @@
+use serde::Serialize;
+
+/// Generates a sing-box config that routes all system traffic through
+/// Aether's local SOCKS5 proxy via a TUN interface.
+///
+/// Uses sing-box 1.13+ config format with minimal route rules to avoid
+/// conflicts between DNS interception and route-based forwarding.
+pub fn generate_config(aether_socks_port: u16) -> String {
+    let config = SingboxConfig {
+        log: LogConfig { level: "info".into() },
+        inbounds: vec![Inbound {
+            type_: "tun".into(),
+            tag: "tun-in".into(),
+            interface_name: Some("aether-tun".into()),
+            address: vec!["172.19.0.1/30".into()],
+            auto_route: true,
+            stack: "gvisor".into(),
+        }],
+        outbounds: vec![
+            Outbound::socks("127.0.0.1", aether_socks_port),
+            Outbound::direct(),
+        ],
+        dns: DnsConfig {
+            servers: vec![
+                DnsServer::https("dns-proxy", "1.1.1.1", "proxy"),
+            ],
+            rules: vec![
+                DnsRule {
+                    action: "route".into(),
+                    server: "dns-proxy".into(),
+                },
+            ],
+            final_: "dns-proxy".into(),
+        },
+        route: RouteConfig {
+            rules: vec![
+                RouteRule {
+                    process_name: Some(vec![
+                        "aether.exe".into(),
+                        "sing-box.exe".into(),
+                    ]),
+                    outbound: Some("direct".into()),
+                },
+            ],
+            final_: "proxy".into(),
+            auto_detect_interface: true,
+        },
+    };
+
+    serde_json::to_string_pretty(&config).expect("sing-box config serialization failed")
+}
+
+#[derive(Serialize)]
+struct SingboxConfig {
+    log: LogConfig,
+    inbounds: Vec<Inbound>,
+    outbounds: Vec<Outbound>,
+    dns: DnsConfig,
+    route: RouteConfig,
+}
+
+#[derive(Serialize)]
+struct LogConfig {
+    level: String,
+}
+
+#[derive(Serialize)]
+struct Inbound {
+    #[serde(rename = "type")]
+    type_: String,
+    tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interface_name: Option<String>,
+    address: Vec<String>,
+    auto_route: bool,
+    stack: String,
+}
+
+#[derive(Serialize)]
+struct Outbound {
+    #[serde(rename = "type")]
+    type_: String,
+    tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_port: Option<u16>,
+}
+
+impl Outbound {
+    fn socks(server: &str, port: u16) -> Self {
+        Self {
+            type_: "socks".into(),
+            tag: "proxy".into(),
+            server: Some(server.into()),
+            server_port: Some(port),
+        }
+    }
+
+    fn direct() -> Self {
+        Self {
+            type_: "direct".into(),
+            tag: "direct".into(),
+            server: None,
+            server_port: None,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct DnsConfig {
+    servers: Vec<DnsServer>,
+    rules: Vec<DnsRule>,
+    #[serde(rename = "final")]
+    final_: String,
+}
+
+#[derive(Serialize)]
+struct DnsServer {
+    #[serde(rename = "type")]
+    type_: String,
+    tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detour: Option<String>,
+}
+
+impl DnsServer {
+    fn https(tag: &str, server: &str, detour: &str) -> Self {
+        Self {
+            type_: "https".into(),
+            tag: tag.into(),
+            server: Some(server.into()),
+            detour: Some(detour.into()),
+        }
+    }
+}
+
+/// DNS rule that routes ALL DNS queries to the proxy DNS server.
+/// In sing-box 1.13+, DNS rules without matching fields act as catch-alls.
+/// The `dns.final` field provides the fallback for unmatched queries.
+#[derive(Serialize)]
+struct DnsRule {
+    action: String,
+    server: String,
+}
+
+#[derive(Serialize)]
+struct RouteConfig {
+    rules: Vec<RouteRule>,
+    #[serde(rename = "final")]
+    final_: String,
+    #[serde(rename = "auto_detect_interface")]
+    auto_detect_interface: bool,
+}
+
+/// Minimal route rule: only exclude sing-box/aether process traffic from
+/// the TUN (prevents routing loop). Everything else goes through the proxy.
+/// Removed: sniff, ip_is_private — these were interfering with DNS
+/// interception and causing the "works 3 seconds then dies" behavior.
+#[derive(Serialize)]
+struct RouteRule {
+    process_name: Option<Vec<String>>,
+    outbound: Option<String>,
+}

--- a/src-tauri/src/singbox/mod.rs
+++ b/src-tauri/src/singbox/mod.rs
@@ -1,0 +1,339 @@
+pub mod config;
+pub mod process;
+pub mod status;
+
+use crate::error::AetherError;
+use crate::events::{now_millis, LogEvent, LOG_EVENT, STATUS_EVENT};
+use crate::state::ConnectionState;
+use process::SingboxProcess;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter, Manager};
+
+pub struct SingboxManager {
+    pub process: Option<SingboxProcess>,
+    pub config_path: Option<PathBuf>,
+    pub active: bool,
+}
+
+impl SingboxManager {
+    pub fn new() -> Self {
+        Self {
+            process: None,
+            config_path: None,
+            active: false,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+}
+
+/// Strip ANSI escape codes from a string (sing-box colors its log output).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            for c2 in chars.by_ref() {
+                if c2.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+fn app_data_dir(app: &AppHandle) -> PathBuf {
+    app.path()
+        .app_data_dir()
+        .unwrap_or_else(|_| std::env::temp_dir())
+}
+
+fn resolve_binary(app: &AppHandle) -> Result<PathBuf, AetherError> {
+    let dir = app
+        .path()
+        .resource_dir()
+        .map_err(|e| AetherError::Internal(e.to_string()))?;
+    let name = if cfg!(windows) { "sing-box.exe" } else { "sing-box" };
+    let path = dir.join("binaries").join(name);
+    if !path.exists() {
+        return Err(AetherError::SingboxBinaryMissing(path.display().to_string()));
+    }
+    Ok(path)
+}
+
+fn write_config(data_dir: &Path, aether_socks_port: u16) -> Result<PathBuf, AetherError> {
+    let config_content = config::generate_config(aether_socks_port);
+    let config_path = data_dir.join("singbox-config.json");
+    fs::write(&config_path, &config_content)
+        .map_err(|e| AetherError::SingboxConfigFailed(e.to_string()))?;
+    Ok(config_path)
+}
+
+fn write_pid(data_dir: &Path, pid: u32) {
+    let _ = fs::write(data_dir.join("singbox.pid"), pid.to_string());
+}
+
+fn clear_pid(data_dir: &Path) {
+    let _ = fs::remove_file(data_dir.join("singbox.pid"));
+}
+
+pub fn reap_orphan(data_dir: &Path) {
+    let path = data_dir.join("singbox.pid");
+    if let Ok(contents) = fs::read_to_string(&path) {
+        if let Ok(pid) = contents.trim().parse::<u32>() {
+            if is_alive(pid) {
+                kill_pid(pid);
+            }
+        }
+        let _ = fs::remove_file(&path);
+    }
+    // Also kill any sing-box process not tracked by our PID file (e.g. left
+    // over from a manual kill or crash).
+    kill_stale_singbox();
+    // Remove a stale TUN adapter if the previous sing-box was killed
+    // forcefully and the wintun driver didn't clean up.
+    cleanup_tun_adapter();
+}
+
+#[cfg(windows)]
+fn is_alive(pid: u32) -> bool {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}")])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&pid.to_string()))
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn kill_pid(pid: u32) {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status();
+}
+
+/// Kill any sing-box.exe process running on the system, regardless of PID
+/// file. Catches orphans from manual kills or crashes.
+#[cfg(windows)]
+fn kill_stale_singbox() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let _ = std::process::Command::new("taskkill")
+        .args(["/IM", "sing-box.exe", "/F"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output();
+}
+
+/// Remove a stale "aether-tun" network adapter left behind when sing-box
+/// was force-killed and the wintun driver didn't clean up.
+#[cfg(windows)]
+fn cleanup_tun_adapter() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    let _ = std::process::Command::new("netsh")
+        .args(["interface", "delete", "interface", "aether-tun"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output();
+}
+
+#[cfg(unix)]
+fn is_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn kill_pid(pid: u32) {
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status();
+}
+
+#[cfg(unix)]
+fn kill_stale_singbox() {}
+
+#[cfg(unix)]
+fn cleanup_tun_adapter() {}
+
+/// Starts the sing-box TUN tunnel. Called after Aether's SOCKS5 is confirmed
+/// live. Writes the config, spawns sing-box, and monitors it on a background
+/// thread. Emits Tunneling state on success.
+pub fn start_tunnel(
+    app: AppHandle,
+    manager: Arc<Mutex<SingboxManager>>,
+    aether_socks_port: u16,
+) -> Result<(), AetherError> {
+    let binary = resolve_binary(&app)?;
+    let data_dir = app_data_dir(&app);
+    std::fs::create_dir_all(&data_dir).map_err(|e| AetherError::Internal(e.to_string()))?;
+
+    {
+        let mgr = manager.lock().unwrap();
+        if mgr.active {
+            return Err(AetherError::SingboxAlreadyRunning);
+        }
+    }
+
+    let config_path = write_config(&data_dir, aether_socks_port)?;
+    // Log the config for debugging.
+    let _ = app.emit(LOG_EVENT, &LogEvent {
+        line: format!("[singbox] config written to {}", config_path.display()),
+        timestamp: now_millis(),
+    });
+    let proc = process::spawn(&binary, &config_path)?;
+    let pid = proc.pid();
+    write_pid(&data_dir, pid);
+
+    {
+        let mut mgr = manager.lock().unwrap();
+        mgr.process = Some(proc);
+        mgr.config_path = Some(config_path);
+        mgr.active = true;
+    }
+
+    // Wait for sing-box to stay alive — if it doesn't crash within the settle
+    // time, the TUN interface is up. No DNS probing needed.
+    let start = Instant::now();
+    let app_clone = app.clone();
+    let manager_clone = Arc::clone(&manager);
+    std::thread::spawn(move || {
+        let deadline = start + status::TUN_STARTUP_TIMEOUT;
+        let mut settled = false;
+        loop {
+            std::thread::sleep(Duration::from_millis(300));
+
+            // Check if sing-box exited prematurely.
+            {
+                let mut mgr = manager_clone.lock().unwrap();
+                if let Some(exit) = mgr.process.as_mut().and_then(|s| s.try_wait()) {
+                    let raw_stderr = mgr.process.as_mut().map(|s| s.read_stderr()).unwrap_or_default();
+                    let stderr = strip_ansi(&raw_stderr);
+                    let msg = if stderr.trim().is_empty() {
+                        format!("sing-box exited ({exit})")
+                    } else {
+                        let last = stderr.lines().filter(|l| !l.trim().is_empty()).last().unwrap_or(&stderr);
+                        format!("sing-box: {last}")
+                    };
+                    mgr.active = false;
+                    mgr.process = None;
+                    clear_pid(&app_data_dir(&app_clone));
+                    let _ = app_clone.emit(
+                        STATUS_EVENT,
+                        &ConnectionState::Error {
+                            message: msg,
+                            phase: "tunnel".into(),
+                        },
+                    );
+                    return;
+                }
+            }
+
+            if !settled {
+                // Once the process has been alive for TUN_SETTLE_TIME, consider it up.
+                if Instant::now().duration_since(start) >= status::TUN_SETTLE_TIME {
+                    settled = true;
+                }
+            }
+
+            if settled {
+                let _ = app_clone.emit(STATUS_EVENT, &ConnectionState::Tunneling {
+                    tun_addr: format!("{}/30", status::TUN_ADDR),
+                    socks_addr: format!("127.0.0.1:{aether_socks_port}"),
+                    connected_at_ms: now_millis(),
+                });
+                // Hand off to long-running monitor.
+                monitor_tunnel(app_clone, manager_clone);
+                return;
+            }
+
+            if Instant::now() >= deadline {
+                // sing-box didn't stay alive — kill and report error.
+                {
+                    let mut mgr = manager_clone.lock().unwrap();
+                    if let Some(proc) = mgr.process.as_mut() {
+                        proc.kill();
+                    }
+                    mgr.active = false;
+                    mgr.process = None;
+                    clear_pid(&app_data_dir(&app_clone));
+                }
+                let _ = app_clone.emit(
+                    STATUS_EVENT,
+                    &ConnectionState::Error {
+                        message: "sing-box TUN interface did not come up in time".into(),
+                        phase: "tunnel".into(),
+                    },
+                );
+                return;
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Watches sing-box after TUN is confirmed live. Only watches for unexpected
+/// process exits — there is no polling beyond that.
+fn monitor_tunnel(app: AppHandle, manager: Arc<Mutex<SingboxManager>>) {
+    loop {
+        std::thread::sleep(Duration::from_millis(500));
+        let mut mgr = manager.lock().unwrap();
+        // Process was cleared by stop_tunnel — exit quietly.
+        if mgr.process.is_none() {
+            return;
+        }
+        if let Some(exit) = mgr.process.as_mut().and_then(|s| s.try_wait()) {
+            let raw_stderr = mgr.process.as_mut().map(|s| s.read_stderr()).unwrap_or_default();
+            let stderr = strip_ansi(&raw_stderr);
+            let msg = if stderr.trim().is_empty() {
+                format!("sing-box TUN lost ({exit})")
+            } else {
+                let last = stderr.lines().filter(|l| !l.trim().is_empty()).last().unwrap_or(&stderr);
+                format!("sing-box: {last}")
+            };
+            mgr.active = false;
+            mgr.process = None;
+            drop(mgr);
+            clear_pid(&app_data_dir(&app));
+            let _ = app.emit(
+                STATUS_EVENT,
+                &ConnectionState::Error {
+                    message: msg,
+                    phase: "tunnel".into(),
+                },
+            );
+            return;
+        }
+    }
+}
+
+/// Stops the sing-box process gracefully.
+pub fn stop_tunnel(app: &AppHandle, manager: &Arc<Mutex<SingboxManager>>) {
+    let data_dir = app_data_dir(app);
+    let mut mgr = manager.lock().unwrap();
+    if let Some(proc) = mgr.process.as_mut() {
+        proc.kill();
+    }
+    mgr.process = None;
+    mgr.active = false;
+    mgr.config_path = None;
+    drop(mgr);
+    clear_pid(&data_dir);
+}

--- a/src-tauri/src/singbox/process.rs
+++ b/src-tauri/src/singbox/process.rs
@@ -1,0 +1,88 @@
+use crate::error::AetherError;
+use std::io::Read;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+pub struct SingboxProcess {
+    child: Child,
+}
+
+impl SingboxProcess {
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+
+    pub fn try_wait(&mut self) -> Option<std::process::ExitStatus> {
+        self.child.try_wait().ok().flatten()
+    }
+
+    pub fn kill(&mut self) {
+        let pid = self.child.id();
+        // Kill first, THEN drain pipes. Draining before kill would block
+        // forever because read_to_end waits for EOF which only arrives
+        // after the process exits.
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            let _ = std::process::Command::new("taskkill")
+                .args(["/F", "/PID", &pid.to_string()])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output();
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = self.child.kill();
+        }
+        // Now that the process is dead, drain pipes and reap.
+        self.drain_pipes();
+        let _ = self.child.wait();
+    }
+
+    fn drain_pipes(&mut self) {
+        if let Some(ref mut stdout) = self.child.stdout {
+            let _ = stdout.read_to_end(&mut Vec::new());
+        }
+        if let Some(ref mut stderr) = self.child.stderr {
+            let _ = stderr.read_to_end(&mut Vec::new());
+        }
+    }
+
+    /// Reads any available stderr output. Used after process exit to get
+    /// the actual error message from sing-box.
+    pub fn read_stderr(&mut self) -> String {
+        let mut buf = String::new();
+        if let Some(ref mut stderr) = self.child.stderr {
+            let _ = stderr.read_to_string(&mut buf);
+        }
+        buf
+    }
+}
+
+/// Spawns sing-box with the given config file path. Unlike Aether, sing-box
+/// is non-interactive so no PTY is needed — plain piped stdio suffices.
+///
+/// On Windows, CREATE_NO_WINDOW prevents a console window from popping up.
+pub fn spawn(binary: &Path, config_path: &Path) -> Result<SingboxProcess, AetherError> {
+    let mut cmd = Command::new(binary);
+    cmd.arg("run")
+        .arg("-c")
+        .arg(config_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // Prevent a console window on Windows.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| AetherError::SpawnFailed(format!("failed to launch sing-box: {e}")))?;
+
+    Ok(SingboxProcess { child })
+}

--- a/src-tauri/src/singbox/status.rs
+++ b/src-tauri/src/singbox/status.rs
@@ -1,0 +1,12 @@
+use std::time::Duration;
+
+/// Address of the sing-box TUN interface (for display purposes).
+pub const TUN_ADDR: &str = "172.19.0.1";
+
+/// How long to wait for the TUN interface to become reachable after sing-box
+/// starts. TUN setup involves driver initialization which can take a moment.
+pub const TUN_STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long to wait after spawning sing-box before considering the TUN live.
+/// If the process stays alive this long without crashing, the TUN is up.
+pub const TUN_SETTLE_TIME: Duration = Duration::from_secs(3);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,12 +1,14 @@
 use crate::aether::AetherManager;
+use crate::singbox::SingboxManager;
 use serde::Serialize;
 use std::sync::{Arc, Mutex};
 
 /// Mirrors the state machine in the approved plan: Idle -> Launching (PTY
 /// spawned, answering prompts) -> Connecting (prompts done, waiting on the
-/// SOCKS5 port to come alive) -> Connected. Any abnormal exit or timeout
-/// from Launching/Connecting/Connected goes to Error rather than a separate
-/// Disconnected state — a clean user-requested stop returns to Idle instead.
+/// SOCKS5 port to come alive) -> Connected -> Tunneling (if sing-box TUN
+/// enabled). Any abnormal exit or timeout goes to Error rather than a
+/// separate Disconnected state — a clean user-requested stop returns to
+/// Idle instead.
 ///
 /// `Reconnecting` is the one addition: an unexpected exit or timeout that
 /// wasn't user-requested retries automatically (see aether/mod.rs's
@@ -23,6 +25,8 @@ pub enum ConnectionState {
     /// a pre-computed elapsed duration, so the frontend can render a live-
     /// updating session timer without needing another event from the backend.
     Connected { socks_addr: String, connected_at_ms: u64 },
+    /// sing-box TUN is active — all system traffic routes through the tunnel.
+    Tunneling { tun_addr: String, socks_addr: String, connected_at_ms: u64 },
     Reconnecting { attempt: u32, max_attempts: u32 },
     Disconnecting,
     Error { message: String, phase: String },
@@ -30,12 +34,14 @@ pub enum ConnectionState {
 
 pub struct AppState {
     pub manager: Arc<Mutex<AetherManager>>,
+    pub singbox: Arc<Mutex<SingboxManager>>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
             manager: Arc::new(Mutex::new(AetherManager::new())),
+            singbox: Arc::new(Mutex::new(SingboxManager::new())),
         }
     }
 }

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -11,6 +11,7 @@ import { ProtocolSelect } from "@/components/ProtocolSelect";
 import { ScanModeToggle } from "@/components/ScanModeToggle";
 import { IpVersionToggle } from "@/components/IpVersionToggle";
 import { MasqueTransportToggle } from "@/components/MasqueTransportToggle";
+import { TunToggle } from "@/components/TunToggle";
 import { useConnectionStore } from "@/state/connectionStore";
 
 function FieldRow({
@@ -103,6 +104,8 @@ export function AdvancedPanel() {
             >
               <MasqueTransportToggle />
             </FieldRow>
+
+            <TunToggle />
 
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1 text-xs text-muted-foreground">

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -15,6 +15,7 @@ function phaseOf(status: ConnectionStatus): Phase {
     case "Disconnecting":
       return "connecting";
     case "Connected":
+    case "Tunneling":
       return "connected";
     case "Error":
       return "error";

--- a/src/components/ConnectionStatusLine.tsx
+++ b/src/components/ConnectionStatusLine.tsx
@@ -66,7 +66,9 @@ function ScanProgressBar({ percent }: { percent: number | null }) {
 export function ConnectionStatusLine() {
   const status = useConnectionStore((s) => s.status);
   const scanBudgetSecs = useConnectionStore((s) => s.scanBudgetSecs);
-  const connectedAt = status.state === "Connected" ? status.connected_at_ms : null;
+  const connectedAt = status.state === "Connected" || status.state === "Tunneling"
+    ? status.connected_at_ms
+    : null;
   const elapsed = useElapsed(connectedAt).formatted;
 
   // Route discovery can legitimately take up to ~2.5 minutes with nothing
@@ -121,6 +123,10 @@ export function ConnectionStatusLine() {
       break;
     case "Connected":
       primary = "Connected";
+      secondary = elapsed;
+      break;
+    case "Tunneling":
+      primary = "Tunnel active";
       secondary = elapsed;
       break;
     case "Disconnecting":

--- a/src/components/TunToggle.tsx
+++ b/src/components/TunToggle.tsx
@@ -1,0 +1,36 @@
+import { Globe, Info } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useConnectionStore } from "@/state/connectionStore";
+
+export function TunToggle() {
+  const tunEnabled = useConnectionStore((s) => s.tunEnabled);
+  const setTunEnabled = useConnectionStore((s) => s.setTunEnabled);
+  const status = useConnectionStore((s) => s.status);
+  const locked = status.state !== "Idle" && status.state !== "Error";
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Globe size={12} />
+        System-wide TUN
+        <Tooltip>
+          <TooltipTrigger aria-label="About System-wide TUN">
+            <Info size={12} />
+          </TooltipTrigger>
+          <TooltipContent>
+            Routes all system traffic through the tunnel using sing-box. Requires administrator
+            privileges (UAC prompt). When enabled, every application on your device uses the
+            tunnel — not just browsers.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <Switch
+        checked={tunEnabled}
+        onCheckedChange={setTunEnabled}
+        disabled={locked}
+        aria-label="System-wide TUN"
+      />
+    </div>
+  );
+}

--- a/src/state/connectionStore.ts
+++ b/src/state/connectionStore.ts
@@ -12,6 +12,7 @@ const MAX_LOG_LINES = 500;
 interface ConnectionState {
   status: ConnectionStatus;
   profile: ConnectionProfile;
+  tunEnabled: boolean;
   logs: LogLine[];
   sidecarError: string | null;
   /** Aether's own route-probe budget in seconds, parsed live out of its log
@@ -26,6 +27,7 @@ interface ConnectionState {
   setIpVersion: (ip_version: ConnectionProfile["ip_version"]) => void;
   setQuickReconnect: (quick_reconnect: boolean) => void;
   setMasqueHttp2: (masque_http2: boolean) => void;
+  setTunEnabled: (enabled: boolean) => void;
   retryAfterSidecarError: () => void;
 }
 
@@ -37,14 +39,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     ip_version: "v4",
     quick_reconnect: true,
     masque_http2: false,
+    tun_enabled: false,
   },
+  tunEnabled: false,
   logs: [],
   sidecarError: null,
   scanBudgetSecs: null,
 
   connect: async () => {
     try {
-      await invoke("connect", { profileOverride: get().profile });
+      await invoke("connect", {
+        profileOverride: get().profile,
+        enableTun: get().tunEnabled,
+      });
     } catch (e) {
       const message = String(e);
       // "Binary not found" (src-tauri/src/aether/mod.rs::resolve_binary) means
@@ -82,6 +89,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setMasqueHttp2: (masque_http2) =>
     set((s) => ({ profile: { ...s.profile, masque_http2 } })),
+
+  setTunEnabled: (tunEnabled) => set({ tunEnabled }),
 
   // Clears the fallback screen so the user can attempt Connect again (e.g.
   // after fixing a broken install) — the next connect() call will re-set
@@ -144,7 +153,7 @@ export async function initConnectionListeners(): Promise<() => void> {
       invoke<ConnectionStatus>("get_status"),
       invoke<ConnectionProfile>("get_default_profile"),
     ]);
-    useConnectionStore.setState({ status, profile });
+    useConnectionStore.setState({ status, profile, tunEnabled: profile.tun_enabled });
   } catch (e) {
     console.error("Failed to load initial connection state:", e);
   }

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -6,6 +6,7 @@ export type ConnectionStatus =
   | { state: "Launching" }
   | { state: "Connecting" }
   | { state: "Connected"; socks_addr: string; connected_at_ms: number }
+  | { state: "Tunneling"; tun_addr: string; socks_addr: string; connected_at_ms: number }
   | { state: "Reconnecting"; attempt: number; max_attempts: number }
   | { state: "Disconnecting" }
   | { state: "Error"; message: string; phase: string };
@@ -24,6 +25,8 @@ export interface ConnectionProfile {
   /** Aether ≥1.2.0: run MASQUE over HTTP/2 (TCP) instead of the default
    * HTTP/3 (QUIC) — for networks that block or throttle UDP. */
   masque_http2: boolean;
+  /** Whether the sing-box TUN toggle is enabled. */
+  tun_enabled: boolean;
 }
 
 export interface LogLine {


### PR DESCRIPTION
In this PR I added a tunnel mode. It uses sing-box binary to create a system-wide tunnel which makes the app truly "one-click"

It's a big change that massively impacts the build size. So if that's not something you'd want to merge, that's understandable.

One thing worth mentioning is that sing-box's license is GPLv3 but yours was AGPLv3. I went on with sing-box's. But if you want, i can undo the LICENSE change.

Also when reinstalling, it's better to delete the data folder too to avoid corrupt data files.

You can find the releases here: https://github.com/zmn-hamid/Aether-GUI-TUN/releases/

Disclaimer: I implemented the whole thing using MimoCode

---

What's new
- sing-box 1.13+ integration — auto-generated config, no deprecated fields
- TUN toggle in Advanced Panel with full connection state machine (Tunneling)
- DNS via HTTPS to Cloudflare through the SOCKS5 tunnel
- Admin elevation via Windows app manifest + runtime check (TUN requires admin)
- Orphan cleanup — kills stale sing-box processes and removes leftover TUN adapters on startup
- Process kill reliability — taskkill /F with pipe drain, CREATE_NO_WINDOW
- TUN setting persists across app restarts via tauri-plugin-sto