### PR TITLE
feat: add obfuscation (noize) profile selection

### DIFF
--- a/src-tauri/src/aether/mod.rs
+++ b/src-tauri/src/aether/mod.rs
@@ -237,7 +237,9 @@ fn monitor_connect(
     data_dir: PathBuf,
     profile: ConnectionProfile,
 ) {
-    let deadline = Instant::now() + status::CONNECT_TIMEOUT;
+    let deadline = Instant::now() + status::connect_timeout(
+        &profile.scan_mode, &profile.protocol, &profile.masque_noize, &profile.wg_noize,
+    );
     let mut announced_connecting = false;
 
     loop {

--- a/src-tauri/src/aether/profiles.rs
+++ b/src-tauri/src/aether/profiles.rs
@@ -62,11 +62,47 @@ impl IpVersion {
     }
 }
 
-/// Note: there is no `local_port` or `obfuscation_profile` field. Manually
-/// running Aether v1.0.1 end to end showed it only ever prompts for these
-/// three settings (protocol / scan mode / IP version) regardless of protocol
-/// choice — the local port is fixed at 1819 by Aether itself, and the
-/// obfuscation profile is auto-selected and merely logged, never prompted.
+/// Obfuscation profile for MASQUE connections. The profile shapes how much
+/// junk/padding Aether injects to disguise the handshake from DPI.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MasqueNoize {
+    Firewall,
+    Gfw,
+    Off,
+}
+
+impl MasqueNoize {
+    pub fn as_flag(&self) -> &'static str {
+        match self {
+            MasqueNoize::Firewall => "firewall",
+            MasqueNoize::Gfw => "gfw",
+            MasqueNoize::Off => "off",
+        }
+    }
+}
+
+/// Obfuscation profile for WireGuard and gool connections.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum WgNoize {
+    Balanced,
+    Aggressive,
+    Light,
+    Off,
+}
+
+impl WgNoize {
+    pub fn as_flag(&self) -> &'static str {
+        match self {
+            WgNoize::Balanced => "balanced",
+            WgNoize::Aggressive => "aggressive",
+            WgNoize::Light => "light",
+            WgNoize::Off => "off",
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ConnectionProfile {
     pub protocol: Protocol,
@@ -84,10 +120,26 @@ pub struct ConnectionProfile {
     /// new interactive "MASQUE transport" prompt in both directions.
     #[serde(default)]
     pub masque_http2: bool,
+    /// Obfuscation profile for MASQUE (firewall/gfw/off). Passed as
+    /// `--noize <value>`. Only sent when the active protocol is MASQUE-based.
+    #[serde(default = "default_masque_noize")]
+    pub masque_noize: MasqueNoize,
+    /// Obfuscation profile for WireGuard/gool (balanced/aggressive/light/off).
+    /// Only sent when the active protocol is WireGuard or gool.
+    #[serde(default = "default_wg_noize")]
+    pub wg_noize: WgNoize,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_masque_noize() -> MasqueNoize {
+    MasqueNoize::Firewall
+}
+
+fn default_wg_noize() -> WgNoize {
+    WgNoize::Balanced
 }
 
 impl ConnectionProfile {
@@ -98,7 +150,7 @@ impl ConnectionProfile {
     /// "reconnect with last gateway?" question, which the GUI must never
     /// leave unanswered.
     pub fn as_args(&self) -> Vec<&'static str> {
-        let mut args = Vec::with_capacity(4);
+        let mut args = Vec::with_capacity(6);
         match self.protocol {
             Protocol::Auto => {} // Aether's own default (MASQUE)
             Protocol::Masque => args.push("--masque"),
@@ -117,6 +169,13 @@ impl ConnectionProfile {
             IpVersion::Both => "--dual",
         });
         args.push(if self.quick_reconnect { "--quick-reconnect" } else { "--no-quick-reconnect" });
+        // Noize profile — pick the value matching the active protocol family.
+        // Auto resolves to MASQUE, so it uses the MASQUE noize set.
+        args.push("--noize");
+        args.push(match self.protocol {
+            Protocol::Auto | Protocol::Masque => self.masque_noize.as_flag(),
+            Protocol::Wireguard | Protocol::Gool => self.wg_noize.as_flag(),
+        });
         args
     }
 }
@@ -130,6 +189,8 @@ impl Default for ConnectionProfile {
             ip_version: IpVersion::V4,
             quick_reconnect: true,
             masque_http2: false,
+            masque_noize: MasqueNoize::Firewall,
+            wg_noize: WgNoize::Balanced,
         }
     }
 }

--- a/src-tauri/src/aether/status.rs
+++ b/src-tauri/src/aether/status.rs
@@ -1,3 +1,4 @@
+use super::profiles::{MasqueNoize, Protocol, ScanMode, WgNoize};
 use std::net::{SocketAddr, TcpStream};
 use std::time::Duration;
 
@@ -16,11 +17,34 @@ pub fn port_is_live() -> bool {
     TcpStream::connect_timeout(&socks_addr(), Duration::from_millis(300)).is_ok()
 }
 
-/// Empirically (manually running v1.0.1 to completion), Aether's own route-
-/// discovery budget goes up to 120s for MASQUE and 80s for WireGuard (its
-/// own "budget=..." log line). The GUI's connect timeout must exceed both,
-/// or it would fire while Aether is still legitimately scanning for a route.
-pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(150);
+/// Aether's own route-discovery budget varies by scan mode and obfuscation
+/// profile — heavier obfuscation adds decoy traffic and inter-packet delays,
+/// stretching every scan. The GUI's timeout must exceed the expected budget
+/// or it would kill Aether while it's still legitimately scanning.
+pub fn connect_timeout(scan_mode: &ScanMode, protocol: &Protocol, masque_noize: &MasqueNoize, wg_noize: &WgNoize) -> Duration {
+    let base = match scan_mode {
+        ScanMode::Turbo => 60u64,
+        ScanMode::Balanced => 150,
+        ScanMode::Thorough => 180,
+        ScanMode::Stealth => 180,
+    };
+    // Heavier obfuscation profiles pad handshakes and add inter-packet
+    // delays, so scans take longer. Add a percentage on top of the base.
+    let noize_extra_pct = match protocol {
+        Protocol::Auto | Protocol::Masque => match masque_noize {
+            MasqueNoize::Firewall => 0,
+            MasqueNoize::Gfw => 25,
+            MasqueNoize::Off => 0,
+        },
+        Protocol::Wireguard | Protocol::Gool => match wg_noize {
+            WgNoize::Balanced => 0,
+            WgNoize::Aggressive => 30,
+            WgNoize::Light => 0,
+            WgNoize::Off => 0,
+        },
+    };
+    Duration::from_secs(base + base * noize_extra_pct / 100)
+}
 
 /// How long to wait after sending Ctrl-C before force-killing. Manually
 /// testing shutdown against the real binary showed it does NOT exit quickly

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const SCREEN_TRANSITION = {
 
 function MainScreen() {
   return (
-    <div className="relative z-10 flex h-full flex-col items-center p-6">
+    <div className="relative z-10 flex h-full flex-col items-center overflow-y-auto p-6">
       <div className="flex flex-1 flex-col items-center justify-center gap-6">
         <ConnectButton />
         <ConnectionStatusLine />

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -11,6 +11,7 @@ import { ProtocolSelect } from "@/components/ProtocolSelect";
 import { ScanModeToggle } from "@/components/ScanModeToggle";
 import { IpVersionToggle } from "@/components/IpVersionToggle";
 import { MasqueTransportToggle } from "@/components/MasqueTransportToggle";
+import { NoizeProfileToggle } from "@/components/NoizeProfileToggle";
 import { useConnectionStore } from "@/state/connectionStore";
 
 function FieldRow({
@@ -102,6 +103,12 @@ export function AdvancedPanel() {
               tooltip="How the MASQUE tunnel carries traffic. HTTP/3 (QUIC) has the fastest handshake; HTTP/2 (TCP) looks like ordinary HTTPS and works where UDP is blocked or throttled. Only applies to the MASQUE protocol."
             >
               <MasqueTransportToggle />
+            </FieldRow>
+            <FieldRow
+              label="Obfuscation"
+              tooltip="Disguises the handshake so DPI can't fingerprint the protocol. Heavier profiles send more decoy traffic — try escalating if the default doesn't connect. Options change based on the selected protocol."
+            >
+              <NoizeProfileToggle />
             </FieldRow>
 
             <div className="flex items-center justify-between">

--- a/src/components/NoizeProfileToggle.tsx
+++ b/src/components/NoizeProfileToggle.tsx
@@ -1,0 +1,110 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useConnectionStore } from "@/state/connectionStore";
+import type { MasqueNoize, WgNoize } from "@/types/connection";
+
+const MASQUE_LABELS: Record<MasqueNoize, string> = {
+  firewall: "Firewall",
+  gfw: "GFW",
+  off: "Off",
+};
+
+const MASQUE_DESCRIPTIONS: Record<MasqueNoize, string> = {
+  firewall:
+    "Balanced obfuscation — gets through most filtered networks without much speed cost. Recommended default.",
+  gfw:
+    "Heavier obfuscation with more decoy traffic. Try this when Firewall can't get through.",
+  off: "No obfuscation. Only for open networks or testing.",
+};
+
+const WG_LABELS: Record<WgNoize, string> = {
+  balanced: "Balanced",
+  aggressive: "Aggressive",
+  light: "Light",
+  off: "Off",
+};
+
+const WG_DESCRIPTIONS: Record<WgNoize, string> = {
+  balanced:
+    "Default — a good balance between stealth and speed for WireGuard traffic.",
+  aggressive:
+    "Heaviest obfuscation with the most decoy packets. For very strict networks.",
+  light: "Minimal obfuscation with the least overhead.",
+  off: "No obfuscation. Only for open networks or testing.",
+};
+
+/** Shows MASQUE or WireGuard/gool obfuscation profiles based on the selected
+ * protocol. Locked outside Idle/Error like every other profile control. */
+export function NoizeProfileToggle() {
+  const status = useConnectionStore((s) => s.status);
+  const protocol = useConnectionStore((s) => s.profile.protocol);
+  const masqueNoize = useConnectionStore((s) => s.profile.masque_noize);
+  const wgNoize = useConnectionStore((s) => s.profile.wg_noize);
+  const setMasqueNoize = useConnectionStore((s) => s.setMasqueNoize);
+  const setWgNoize = useConnectionStore((s) => s.setWgNoize);
+
+  const locked = status.state !== "Idle" && status.state !== "Error";
+  const isMasque = protocol === "auto" || protocol === "masque";
+
+  if (isMasque) {
+    return (
+      <ToggleGroup
+        type="single"
+        value={masqueNoize}
+        onValueChange={(v) => {
+          if (v) setMasqueNoize(v as MasqueNoize);
+        }}
+        disabled={locked}
+        className="w-full gap-0 rounded-full bg-black/20 p-1 ring-1 ring-white/10"
+      >
+        {(Object.keys(MASQUE_LABELS) as MasqueNoize[]).map((n) => (
+          <Tooltip key={n}>
+            <TooltipTrigger asChild>
+              <span className="flex-1">
+                <ToggleGroupItem
+                  value={n}
+                  size="sm"
+                  aria-label={MASQUE_LABELS[n]}
+                  className="w-full rounded-full text-muted-foreground transition-colors duration-75 data-[state=on]:bg-primary/85 data-[state=on]:text-primary-foreground"
+                >
+                  {MASQUE_LABELS[n]}
+                </ToggleGroupItem>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{MASQUE_DESCRIPTIONS[n]}</TooltipContent>
+          </Tooltip>
+        ))}
+      </ToggleGroup>
+    );
+  }
+
+  return (
+    <ToggleGroup
+      type="single"
+      value={wgNoize}
+      onValueChange={(v) => {
+        if (v) setWgNoize(v as WgNoize);
+      }}
+      disabled={locked}
+      className="w-full gap-0 rounded-full bg-black/20 p-1 ring-1 ring-white/10"
+    >
+      {(Object.keys(WG_LABELS) as WgNoize[]).map((n) => (
+        <Tooltip key={n}>
+          <TooltipTrigger asChild>
+            <span className="flex-1">
+              <ToggleGroupItem
+                value={n}
+                size="sm"
+                aria-label={WG_LABELS[n]}
+                className="w-full rounded-full text-muted-foreground transition-colors duration-75 data-[state=on]:bg-primary/85 data-[state=on]:text-primary-foreground"
+              >
+                {WG_LABELS[n]}
+              </ToggleGroupItem>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{WG_DESCRIPTIONS[n]}</TooltipContent>
+        </Tooltip>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/src/state/connectionStore.ts
+++ b/src/state/connectionStore.ts
@@ -5,6 +5,8 @@ import type {
   ConnectionProfile,
   ConnectionStatus,
   LogLine,
+  MasqueNoize,
+  WgNoize,
 } from "@/types/connection";
 
 const MAX_LOG_LINES = 500;
@@ -26,6 +28,8 @@ interface ConnectionState {
   setIpVersion: (ip_version: ConnectionProfile["ip_version"]) => void;
   setQuickReconnect: (quick_reconnect: boolean) => void;
   setMasqueHttp2: (masque_http2: boolean) => void;
+  setMasqueNoize: (masque_noize: MasqueNoize) => void;
+  setWgNoize: (wg_noize: WgNoize) => void;
   retryAfterSidecarError: () => void;
 }
 
@@ -37,6 +41,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     ip_version: "v4",
     quick_reconnect: true,
     masque_http2: false,
+    masque_noize: "firewall",
+    wg_noize: "balanced",
   },
   logs: [],
   sidecarError: null,
@@ -82,6 +88,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setMasqueHttp2: (masque_http2) =>
     set((s) => ({ profile: { ...s.profile, masque_http2 } })),
+
+  setMasqueNoize: (masque_noize) =>
+    set((s) => ({ profile: { ...s.profile, masque_noize } })),
+
+  setWgNoize: (wg_noize) =>
+    set((s) => ({ profile: { ...s.profile, wg_noize } })),
 
   // Clears the fallback screen so the user can attempt Connect again (e.g.
   // after fixing a broken install) — the next connect() call will re-set

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -13,6 +13,8 @@ export type ConnectionStatus =
 export type Protocol = "auto" | "masque" | "wireguard" | "gool";
 export type ScanMode = "turbo" | "balanced" | "thorough" | "stealth";
 export type IpVersion = "v4" | "v6" | "both";
+export type MasqueNoize = "firewall" | "gfw" | "off";
+export type WgNoize = "balanced" | "aggressive" | "light" | "off";
 
 export interface ConnectionProfile {
   protocol: Protocol;
@@ -24,6 +26,10 @@ export interface ConnectionProfile {
   /** Aether ≥1.2.0: run MASQUE over HTTP/2 (TCP) instead of the default
    * HTTP/3 (QUIC) — for networks that block or throttle UDP. */
   masque_http2: boolean;
+  /** Obfuscation profile for MASQUE (firewall/gfw/off). */
+  masque_noize: MasqueNoize;
+  /** Obfuscation profile for WireGuard/gool (balanced/aggressive/light/off). */
+  wg_noize: WgNoize;
 }
 
 export interface LogLine {


### PR DESCRIPTION
## Summary

- Add a new **Obfuscation** toggle to the Advanced panel that lets users choose Aether's `--noize` profile directly from the GUI
- The toggle **switches its options based on the selected protocol**: MASQUE shows firewall/gfw/off, WireGuard/gool shows balanced/aggressive/light/off
- Replace the fixed 150s connect timeout with a function that factors in both scan mode and obfuscation level

### Problem

The GUI had no way to control Aether's obfuscation profile. Users on heavily censored networks where the default profile (firewall for MASQUE, balanced for WireGuard) wasn't getting through had to drop to the CLI and pass `--noize gfw` or `--noize aggressive` manually. This is the most common escalation path in Aether's troubleshooting guide, and the GUI was blind to it.

Additionally, the connect timeout was a single 150s constant regardless of scan mode or obfuscation — heavier profiles add inter-packet delays that stretch scanning, and the GUI could time out before Aether finished a legitimate scan.

### Solution

**Rust backend** (`profiles.rs`, `status.rs`, `mod.rs`):
- Two new enums: `MasqueNoize` (firewall/gfw/off) and `WgNoize` (balanced/aggressive/light/off)
- Both stored in `ConnectionProfile` with `serde(default)` for backward compatibility
- `as_args()` passes `--noize <value>` based on the active protocol family
- `connect_timeout()` replaces the constant — base timeout per scan mode, plus a percentage for heavy obfuscation (gfw +25%, aggressive +30%)

**Frontend** (`NoizeProfileToggle.tsx`, `connectionStore.ts`, `connection.ts`, `AdvancedPanel.tsx`, `App.tsx`):
- New `NoizeProfileToggle` component that renders different option sets based on protocol
- Zustand store gains `masque_noize`/`wg_noize` fields and setters
- Obfuscation field row added to AdvancedPanel after MASQUE Transport
- MainScreen container gets `overflow-y-auto` so the expanded panel scrolls instead of clipping

### Files changed

| File | Change |
|---|---|
| `src-tauri/src/aether/profiles.rs` | `MasqueNoize`/`WgNoize` enums, profile fields, `--noize` in `as_args()` |
| `src-tauri/src/aether/status.rs` | `connect_timeout()` function replaces `CONNECT_TIMEOUT` constant |
| `src-tauri/src/aether/mod.rs` | Call site updated to use new timeout function |
| `src/types/connection.ts` | `MasqueNoize`/`WgNoize` types added |
| `src/state/connectionStore.ts` | Store fields + setters for both noize types |
| `src/components/NoizeProfileToggle.tsx` | New component — protocol-aware toggle |
| `src/components/AdvancedPanel.tsx` | Obfuscation field row added |
| `src/App.tsx` | `overflow-y-auto` on MainScreen for scroll support |

## Test plan

- [x] `cargo check` — compiles cleanly (only pre-existing warning in `focus.rs`)
- [x] `cargo test` — all 5 existing tests pass
- [x] `tsc --noEmit` — TypeScript type-checks with no errors
- [x] `Record<MasqueNoize/WgNoize, string>` maps enforce compile-time completeness
- [x] Exhaustive `match` arms in Rust enforce completeness
- [x] Visual: launched with `tauri dev`, opened Advanced panel, confirmed Obfuscation toggle renders correctly with tooltips, switches between MASQUE and WG option sets when protocol changes, and the panel scrolls when expanded
- [x] Backward-compatible: `serde(default)` on new fields — profiles saved by v0.4.0 deserialize cleanly
- [ ] Manual: connect with gfw profile, verify `--noize gfw` appears in spawned process args
- [ ] Manual: connect with aggressive profile on WireGuard, verify `--noize aggressive` is passed
- [ ] Cross-platform: Windows, macOS, Linux builds via `tauri build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)