### PR TITLE
feat: custom SOCKS5 bind address and LAN toggle

### DIFF
--- a/src-tauri/src/aether/mod.rs
+++ b/src-tauri/src/aether/mod.rs
@@ -95,8 +95,9 @@ pub fn start_connect(
         // checked under the same lock as the state check above so a rapid
         // double-click can't race two connect() calls past this guard before
         // the first transitions to Launching.
-        if status::port_is_live() {
-            return Err(AetherError::PortInUse(status::SOCKS_PORT));
+        let socks = status::parse_bind_address(&profile.bind_address);
+        if status::port_is_live(&socks) {
+            return Err(AetherError::PortInUse(socks.port()));
         }
         mgr.state = ConnectionState::Launching;
         // A fresh user-initiated connect always gets a full retry budget,
@@ -238,6 +239,7 @@ fn monitor_connect(
     profile: ConnectionProfile,
 ) {
     let deadline = Instant::now() + status::CONNECT_TIMEOUT;
+    let socks = status::parse_bind_address(&profile.bind_address);
     let mut announced_connecting = false;
 
     loop {
@@ -274,9 +276,9 @@ fn monitor_connect(
             }
         }
 
-        if status::port_is_live() {
+        if status::port_is_live(&socks) {
             let new_state = ConnectionState::Connected {
-                socks_addr: format!("127.0.0.1:{}", status::SOCKS_PORT),
+                socks_addr: profile.bind_address.clone(),
                 connected_at_ms: now_millis(),
             };
             mgr.state = new_state.clone();

--- a/src-tauri/src/aether/profiles.rs
+++ b/src-tauri/src/aether/profiles.rs
@@ -62,11 +62,6 @@ impl IpVersion {
     }
 }
 
-/// Note: there is no `local_port` or `obfuscation_profile` field. Manually
-/// running Aether v1.0.1 end to end showed it only ever prompts for these
-/// three settings (protocol / scan mode / IP version) regardless of protocol
-/// choice — the local port is fixed at 1819 by Aether itself, and the
-/// obfuscation profile is auto-selected and merely logged, never prompted.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ConnectionProfile {
     pub protocol: Protocol,
@@ -84,10 +79,19 @@ pub struct ConnectionProfile {
     /// new interactive "MASQUE transport" prompt in both directions.
     #[serde(default)]
     pub masque_http2: bool,
+    /// Local SOCKS5 listen address (`--bind`). Aether defaults to
+    /// 127.0.0.1:1819; users can change the port to avoid conflicts or bind
+    /// to 0.0.0.0 to expose the proxy on the LAN.
+    #[serde(default = "default_bind_address")]
+    pub bind_address: String,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_bind_address() -> String {
+    "127.0.0.1:1819".into()
 }
 
 impl ConnectionProfile {
@@ -97,26 +101,30 @@ impl ConnectionProfile {
     /// ALWAYS passed: without either, 1.1.1 asks its own interactive
     /// "reconnect with last gateway?" question, which the GUI must never
     /// leave unanswered.
-    pub fn as_args(&self) -> Vec<&'static str> {
-        let mut args = Vec::with_capacity(4);
+    pub fn as_args(&self) -> Vec<String> {
+        let mut args = Vec::with_capacity(6);
         match self.protocol {
             Protocol::Auto => {} // Aether's own default (MASQUE)
-            Protocol::Masque => args.push("--masque"),
-            Protocol::Wireguard => args.push("--wg"),
-            Protocol::Gool => args.push("--gool"),
+            Protocol::Masque => args.push("--masque".into()),
+            Protocol::Wireguard => args.push("--wg".into()),
+            Protocol::Gool => args.push("--gool".into()),
         }
         args.push(match self.scan_mode {
-            ScanMode::Turbo => "--turbo",
-            ScanMode::Balanced => "--balanced",
-            ScanMode::Thorough => "--thorough",
-            ScanMode::Stealth => "--stealth",
+            ScanMode::Turbo => "--turbo".into(),
+            ScanMode::Balanced => "--balanced".into(),
+            ScanMode::Thorough => "--thorough".into(),
+            ScanMode::Stealth => "--stealth".into(),
         });
         args.push(match self.ip_version {
-            IpVersion::V4 => "-4",
-            IpVersion::V6 => "-6",
-            IpVersion::Both => "--dual",
+            IpVersion::V4 => "-4".into(),
+            IpVersion::V6 => "-6".into(),
+            IpVersion::Both => "--dual".into(),
         });
-        args.push(if self.quick_reconnect { "--quick-reconnect" } else { "--no-quick-reconnect" });
+        args.push(if self.quick_reconnect { "--quick-reconnect".into() } else { "--no-quick-reconnect".into() });
+        if self.bind_address != default_bind_address() {
+            args.push("--bind".into());
+            args.push(self.bind_address.clone());
+        }
         args
     }
 }
@@ -130,6 +138,7 @@ impl Default for ConnectionProfile {
             ip_version: IpVersion::V4,
             quick_reconnect: true,
             masque_http2: false,
+            bind_address: default_bind_address(),
         }
     }
 }

--- a/src-tauri/src/aether/pty.rs
+++ b/src-tauri/src/aether/pty.rs
@@ -74,7 +74,7 @@ pub fn spawn(
     // prompts below normally never appear — read_loop's prompt answering is
     // kept as a fallback for output-format drift.
     for arg in profile.as_args() {
-        cmd.arg(arg);
+        cmd.arg(&arg);
     }
     // Env var, not a flag (see ConnectionProfile::masque_http2's doc-comment):
     // any value suppresses Aether 1.2.0's interactive "MASQUE transport"

--- a/src-tauri/src/aether/status.rs
+++ b/src-tauri/src/aether/status.rs
@@ -1,10 +1,21 @@
-use std::net::{SocketAddr, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::time::Duration;
 
-pub const SOCKS_PORT: u16 = 1819;
+pub const DEFAULT_SOCKS_ADDR: &str = "127.0.0.1:1819";
 
-pub fn socks_addr() -> SocketAddr {
-    SocketAddr::from(([127, 0, 0, 1], SOCKS_PORT))
+pub fn parse_bind_address(addr: &str) -> SocketAddr {
+    addr.parse().unwrap_or_else(|_| DEFAULT_SOCKS_ADDR.parse().unwrap())
+}
+
+/// Returns the address to TCP-connect to for liveness probes. When Aether
+/// listens on 0.0.0.0 (all interfaces), we must probe 127.0.0.1 instead —
+/// you can listen on the unspecified address but can't connect to it.
+fn probe_addr(listen: &SocketAddr) -> SocketAddr {
+    if listen.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen.port())
+    } else {
+        *listen
+    }
 }
 
 /// Ground-truth "are we connected" signal: try to open a TCP connection to
@@ -12,8 +23,8 @@ pub fn socks_addr() -> SocketAddr {
 /// wording across releases, which is the actual fragility PTY-automation
 /// accepts (see the approved plan) — log-line matching is only ever used to
 /// fail fast / show a nicer message, never as the sole source of truth.
-pub fn port_is_live() -> bool {
-    TcpStream::connect_timeout(&socks_addr(), Duration::from_millis(300)).is_ok()
+pub fn port_is_live(addr: &SocketAddr) -> bool {
+    TcpStream::connect_timeout(&probe_addr(addr), Duration::from_millis(300)).is_ok()
 }
 
 /// Empirically (manually running v1.0.1 to completion), Aether's own route-

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -11,6 +11,7 @@ import { ProtocolSelect } from "@/components/ProtocolSelect";
 import { ScanModeToggle } from "@/components/ScanModeToggle";
 import { IpVersionToggle } from "@/components/IpVersionToggle";
 import { MasqueTransportToggle } from "@/components/MasqueTransportToggle";
+import { BindAddressField } from "@/components/BindAddressField";
 import { useConnectionStore } from "@/state/connectionStore";
 
 function FieldRow({
@@ -102,6 +103,12 @@ export function AdvancedPanel() {
               tooltip="How the MASQUE tunnel carries traffic. HTTP/3 (QUIC) has the fastest handshake; HTTP/2 (TCP) looks like ordinary HTTPS and works where UDP is blocked or throttled. Only applies to the MASQUE protocol."
             >
               <MasqueTransportToggle />
+            </FieldRow>
+            <FieldRow
+              label="SOCKS5 Proxy"
+              tooltip="The local address Aether's SOCKS5 proxy listens on. Change the port to avoid conflicts, or enable LAN to share the tunnel with other devices on your network."
+            >
+              <BindAddressField />
             </FieldRow>
 
             <div className="flex items-center justify-between">

--- a/src/components/BindAddressField.tsx
+++ b/src/components/BindAddressField.tsx
@@ -1,0 +1,56 @@
+import { useConnectionStore } from "@/state/connectionStore";
+import { Switch } from "@/components/ui/switch";
+
+const DEFAULT_PORT = "1819";
+const LOOPBACK = "127.0.0.1";
+const ANY = "0.0.0.0";
+
+function splitAddr(addr: string): { host: string; port: string } {
+  const last = addr.lastIndexOf(":");
+  if (last === -1) return { host: LOOPBACK, port: addr || DEFAULT_PORT };
+  return { host: addr.slice(0, last) || LOOPBACK, port: addr.slice(last + 1) || DEFAULT_PORT };
+}
+
+export function BindAddressField() {
+  const bind = useConnectionStore((s) => s.profile.bind_address);
+  const setBindAddress = useConnectionStore((s) => s.setBindAddress);
+  const status = useConnectionStore((s) => s.status);
+  const locked = status.state !== "Idle" && status.state !== "Error";
+
+  const { host, port } = splitAddr(bind);
+  const lan = host === ANY;
+
+  const rebuild = (h: string, p: string) => setBindAddress(`${h}:${p}`);
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        inputMode="numeric"
+        value={port}
+        disabled={locked}
+        onChange={(e) => {
+          // Allow only digits, max 5 chars
+          const v = e.target.value.replace(/\D/g, "").slice(0, 5);
+          rebuild(host, v);
+        }}
+        onBlur={() => {
+          // Clamp to valid port range on blur
+          const n = Number(port);
+          if (!port || n < 1 || n > 65535) rebuild(host, DEFAULT_PORT);
+        }}
+        className="h-8 w-20 rounded-md bg-black/20 px-2 text-center text-xs text-foreground ring-1 ring-white/10 outline-none focus:ring-primary disabled:opacity-50"
+        aria-label="SOCKS5 port"
+      />
+      <div className="flex items-center gap-1.5">
+        <Switch
+          checked={lan}
+          onCheckedChange={(on) => rebuild(on ? ANY : LOOPBACK, port)}
+          disabled={locked}
+          aria-label="Allow LAN connections"
+        />
+        <span className="text-xs text-muted-foreground">LAN</span>
+      </div>
+    </div>
+  );
+}

--- a/src/state/connectionStore.ts
+++ b/src/state/connectionStore.ts
@@ -26,6 +26,7 @@ interface ConnectionState {
   setIpVersion: (ip_version: ConnectionProfile["ip_version"]) => void;
   setQuickReconnect: (quick_reconnect: boolean) => void;
   setMasqueHttp2: (masque_http2: boolean) => void;
+  setBindAddress: (bind_address: string) => void;
   retryAfterSidecarError: () => void;
 }
 
@@ -37,6 +38,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     ip_version: "v4",
     quick_reconnect: true,
     masque_http2: false,
+    bind_address: "127.0.0.1:1819",
   },
   logs: [],
   sidecarError: null,
@@ -82,6 +84,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setMasqueHttp2: (masque_http2) =>
     set((s) => ({ profile: { ...s.profile, masque_http2 } })),
+
+  setBindAddress: (bind_address) =>
+    set((s) => ({ profile: { ...s.profile, bind_address } })),
 
   // Clears the fallback screen so the user can attempt Connect again (e.g.
   // after fixing a broken install) — the next connect() call will re-set

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -24,6 +24,8 @@ export interface ConnectionProfile {
   /** Aether ≥1.2.0: run MASQUE over HTTP/2 (TCP) instead of the default
    * HTTP/3 (QUIC) — for networks that block or throttle UDP. */
   masque_http2: boolean;
+  /** Local SOCKS5 listen address (--bind). Default 127.0.0.1:1819. */
+  bind_address: string;
 }
 
 export interface LogLine {


### PR DESCRIPTION
## Problem

Issue #6 asked for a custom SOCKS port. Aether already supports `--bind <host:port>` (default `127.0.0.1:1819`), but Aether-GUI hard-coded that address for:

- pre-connect "port in use" checks
- connect liveness probing
- the `Connected` state's `socks_addr`

Users couldn't change the port to avoid conflicts, or bind to `0.0.0.0` to share the tunnel on the LAN.

## Solution

Expose bind address as a profile setting with a small Advanced-panel control:

- **Port field** — defaults to `1819`, digits only, clamped to 1–65535 on blur
- **LAN switch** — flips host between `127.0.0.1` and `0.0.0.0`

When non-default, the GUI passes `--bind <addr>` to Aether. Liveness probes use `127.0.0.1:<port>` when listening on the unspecified address (you can't TCP-connect to `0.0.0.0`).

## Implementation

- `ConnectionProfile.bind_address` with `serde(default)` → `"127.0.0.1:1819"` (old profiles load cleanly)
- `as_args()` now returns `Vec<String>` and appends `--bind` only when non-default
- `status::port_is_live(addr)` / `parse_bind_address` replace the hard-coded `SOCKS_PORT`
- Connected state reports the configured bind address
- New `BindAddressField` in Advanced → SOCKS5 Proxy

## Testing

- `cargo test` — 5 passed
- `cargo check` — 0 errors (pre-existing unused import warning in `focus.rs` only)
- `npx tsc --noEmit` — clean
- `npx vite build` — clean

## Out of scope

System tray (also requested in #6) is a separate, larger feature and is not included here.