### PR TITLE
feat: custom SOCKS5 bind address, LAN toggle, and minimize to system tray

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,8 @@
     "core:window:allow-start-dragging",
     "core:window:allow-close",
     "core:window:allow-minimize",
-    "core:window:allow-toggle-maximize"
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-show",
+    "core:window:allow-hide"
   ]
 }

--- a/src-tauri/src/aether/mod.rs
+++ b/src-tauri/src/aether/mod.rs
@@ -95,8 +95,9 @@ pub fn start_connect(
         // checked under the same lock as the state check above so a rapid
         // double-click can't race two connect() calls past this guard before
         // the first transitions to Launching.
-        if status::port_is_live() {
-            return Err(AetherError::PortInUse(status::SOCKS_PORT));
+        let socks = status::parse_bind_address(&profile.bind_address);
+        if status::port_is_live(&socks) {
+            return Err(AetherError::PortInUse(socks.port()));
         }
         mgr.state = ConnectionState::Launching;
         // A fresh user-initiated connect always gets a full retry budget,
@@ -240,6 +241,7 @@ fn monitor_connect(
     let deadline = Instant::now() + status::connect_timeout(
         &profile.scan_mode, &profile.protocol, &profile.masque_noize, &profile.wg_noize,
     );
+    let socks = status::parse_bind_address(&profile.bind_address);
     let mut announced_connecting = false;
 
     loop {
@@ -276,9 +278,9 @@ fn monitor_connect(
             }
         }
 
-        if status::port_is_live() {
+        if status::port_is_live(&socks) {
             let new_state = ConnectionState::Connected {
-                socks_addr: format!("127.0.0.1:{}", status::SOCKS_PORT),
+                socks_addr: profile.bind_address.clone(),
                 connected_at_ms: now_millis(),
             };
             mgr.state = new_state.clone();

--- a/src-tauri/src/aether/profiles.rs
+++ b/src-tauri/src/aether/profiles.rs
@@ -130,6 +130,10 @@ pub struct ConnectionProfile {
     /// Only sent when the active protocol is WireGuard or gool.
     #[serde(default = "default_wg_noize")]
     pub wg_noize: WgNoize,
+    /// Local SOCKS5 listen address (`--bind`). Aether defaults to
+    /// 127.0.0.1:1819; users can change the port or bind to 0.0.0.0 for LAN.
+    #[serde(default = "default_bind_address")]
+    pub bind_address: String,
 }
 
 fn default_true() -> bool {
@@ -144,6 +148,10 @@ fn default_wg_noize() -> WgNoize {
     WgNoize::Balanced
 }
 
+fn default_bind_address() -> String {
+    "127.0.0.1:1819".into()
+}
+
 impl ConnectionProfile {
     /// CLI flags for Aether ≥1.1.1 — the whole profile is passed up front so
     /// the interactive prompts never appear (the PTY prompt-answering in
@@ -151,35 +159,104 @@ impl ConnectionProfile {
     /// ALWAYS passed: without either, 1.1.1 asks its own interactive
     /// "reconnect with last gateway?" question, which the GUI must never
     /// leave unanswered.
-    pub fn as_args(&self) -> Vec<&'static str> {
-        let mut args = Vec::with_capacity(6);
+    pub fn as_args(&self) -> Vec<String> {
+        let mut args = Vec::with_capacity(10);
         match self.protocol {
-            Protocol::Auto => {} // Aether's own default (MASQUE)
-            Protocol::Masque => args.push("--masque"),
-            Protocol::Wireguard => args.push("--wg"),
-            Protocol::Gool => args.push("--gool"),
+            Protocol::Auto => {}
+            Protocol::Masque => args.push("--masque".into()),
+            Protocol::Wireguard => args.push("--wg".into()),
+            Protocol::Gool => args.push("--gool".into()),
         }
         args.push(match self.scan_mode {
-            ScanMode::Turbo => "--turbo",
-            ScanMode::Balanced => "--balanced",
-            ScanMode::Thorough => "--thorough",
-            ScanMode::Stealth => "--stealth",
-            ScanMode::Ironclad => "--ironclad",
+            ScanMode::Turbo => "--turbo".into(),
+            ScanMode::Balanced => "--balanced".into(),
+            ScanMode::Thorough => "--thorough".into(),
+            ScanMode::Stealth => "--stealth".into(),
+            ScanMode::Ironclad => "--ironclad".into(),
         });
         args.push(match self.ip_version {
-            IpVersion::V4 => "-4",
-            IpVersion::V6 => "-6",
-            IpVersion::Both => "--dual",
+            IpVersion::V4 => "-4".into(),
+            IpVersion::V6 => "-6".into(),
+            IpVersion::Both => "--dual".into(),
         });
-        args.push(if self.quick_reconnect { "--quick-reconnect" } else { "--no-quick-reconnect" });
+        args.push(if self.quick_reconnect { "--quick-reconnect".into() } else { "--no-quick-reconnect".into() });
         // Noize profile — pick the value matching the active protocol family.
-        // Auto resolves to MASQUE, so it uses the MASQUE noize set.
-        args.push("--noize");
+        args.push("--noize".into());
         args.push(match self.protocol {
             Protocol::Auto | Protocol::Masque => self.masque_noize.as_flag(),
             Protocol::Wireguard | Protocol::Gool => self.wg_noize.as_flag(),
-        });
+        }.into());
+        // Only forward --bind when non-default and parseable.
+        if self.bind_address != default_bind_address()
+            && self.bind_address.parse::<std::net::SocketAddr>().is_ok()
+        {
+            args.push("--bind".into());
+            args.push(self.bind_address.clone());
+        }
         args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_omits_bind_flag() {
+        let p = ConnectionProfile::default();
+        let args = p.as_args();
+        assert!(!args.iter().any(|a| a == "--bind"), "args={args:?}");
+    }
+
+    #[test]
+    fn custom_port_emits_bind() {
+        let mut p = ConnectionProfile::default();
+        p.bind_address = "127.0.0.1:1919".into();
+        let args = p.as_args();
+        let i = args.iter().position(|a| a == "--bind").expect("missing --bind");
+        assert_eq!(args.get(i + 1).map(String::as_str), Some("127.0.0.1:1919"));
+    }
+
+    #[test]
+    fn lan_bind_emits_bind() {
+        let mut p = ConnectionProfile::default();
+        p.bind_address = "0.0.0.0:1819".into();
+        let args = p.as_args();
+        let i = args.iter().position(|a| a == "--bind").expect("missing --bind");
+        assert_eq!(args.get(i + 1).map(String::as_str), Some("0.0.0.0:1819"));
+    }
+
+    #[test]
+    fn lan_with_custom_port_emits_bind() {
+        let mut p = ConnectionProfile::default();
+        p.bind_address = "0.0.0.0:9999".into();
+        let args = p.as_args();
+        let i = args.iter().position(|a| a == "--bind").expect("missing --bind");
+        assert_eq!(args.get(i + 1).map(String::as_str), Some("0.0.0.0:9999"));
+    }
+
+    #[test]
+    fn invalid_bind_is_not_forwarded() {
+        let mut p = ConnectionProfile::default();
+        p.bind_address = "127.0.0.1:".into();
+        let args = p.as_args();
+        assert!(!args.iter().any(|a| a == "--bind"), "args={args:?}");
+    }
+
+    #[test]
+    fn old_profile_json_gets_defaults() {
+        let json = r#"{"protocol":"auto","scan_mode":"balanced","ip_version":"v4","quick_reconnect":true,"masque_http2":false}"#;
+        let p: ConnectionProfile = serde_json::from_str(json).unwrap();
+        assert_eq!(p.bind_address, "127.0.0.1:1819");
+        assert_eq!(p.masque_noize, MasqueNoize::Firewall);
+    }
+
+    #[test]
+    fn default_emits_noize() {
+        let p = ConnectionProfile::default();
+        let args = p.as_args();
+        let i = args.iter().position(|a| a == "--noize").expect("missing --noize");
+        assert_eq!(args.get(i + 1).map(String::as_str), Some("firewall"));
     }
 }
 
@@ -194,6 +271,7 @@ impl Default for ConnectionProfile {
             masque_http2: false,
             masque_noize: MasqueNoize::Firewall,
             wg_noize: WgNoize::Balanced,
+            bind_address: default_bind_address(),
         }
     }
 }

--- a/src-tauri/src/aether/status.rs
+++ b/src-tauri/src/aether/status.rs
@@ -1,20 +1,25 @@
 use super::profiles::{MasqueNoize, Protocol, ScanMode, WgNoize};
-use std::net::{SocketAddr, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::time::Duration;
 
-pub const SOCKS_PORT: u16 = 1819;
+pub const DEFAULT_SOCKS_ADDR: &str = "127.0.0.1:1819";
 
-pub fn socks_addr() -> SocketAddr {
-    SocketAddr::from(([127, 0, 0, 1], SOCKS_PORT))
+pub fn parse_bind_address(addr: &str) -> SocketAddr {
+    addr.parse().unwrap_or_else(|_| DEFAULT_SOCKS_ADDR.parse().unwrap())
 }
 
-/// Ground-truth "are we connected" signal: try to open a TCP connection to
-/// Aether's local SOCKS5 port. This is immune to Aether changing its log
-/// wording across releases, which is the actual fragility PTY-automation
-/// accepts (see the approved plan) — log-line matching is only ever used to
-/// fail fast / show a nicer message, never as the sole source of truth.
-pub fn port_is_live() -> bool {
-    TcpStream::connect_timeout(&socks_addr(), Duration::from_millis(300)).is_ok()
+/// When Aether listens on 0.0.0.0, we probe 127.0.0.1 instead.
+fn probe_addr(listen: &SocketAddr) -> SocketAddr {
+    if listen.ip().is_unspecified() {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen.port())
+    } else {
+        *listen
+    }
+}
+
+/// Ground-truth "are we connected" signal: TCP connect to SOCKS5 port.
+pub fn port_is_live(addr: &SocketAddr) -> bool {
+    TcpStream::connect_timeout(&probe_addr(addr), Duration::from_millis(300)).is_ok()
 }
 
 /// Aether's own route-discovery budget varies by scan mode and obfuscation
@@ -67,3 +72,64 @@ pub const GRACEFUL_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 pub const MAX_AUTO_RETRIES: u32 = 3;
 pub const RETRY_BACKOFF: [Duration; MAX_AUTO_RETRIES as usize] =
     [Duration::from_secs(2), Duration::from_secs(5), Duration::from_secs(10)];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+
+    #[test]
+    fn parse_valid_and_invalid() {
+        assert_eq!(parse_bind_address("127.0.0.1:1919"), "127.0.0.1:1919".parse().unwrap());
+        assert_eq!(parse_bind_address("0.0.0.0:1819"), "0.0.0.0:1819".parse().unwrap());
+        assert_eq!(parse_bind_address("0.0.0.0:9999"), "0.0.0.0:9999".parse().unwrap());
+        assert_eq!(parse_bind_address("127.0.0.1:"), DEFAULT_SOCKS_ADDR.parse().unwrap());
+        assert_eq!(parse_bind_address("not-an-addr"), DEFAULT_SOCKS_ADDR.parse().unwrap());
+    }
+
+    #[test]
+    fn probe_addr_rewrites_unspecified() {
+        let any: SocketAddr = "0.0.0.0:1919".parse().unwrap();
+        assert_eq!(probe_addr(&any), "127.0.0.1:1919".parse().unwrap());
+        let loopback: SocketAddr = "127.0.0.1:1919".parse().unwrap();
+        assert_eq!(probe_addr(&loopback), loopback);
+    }
+
+    #[test]
+    fn port_is_live_detects_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || { let _ = listener.accept(); });
+        assert!(port_is_live(&addr));
+        let dead: SocketAddr = format!("127.0.0.1:{}", addr.port().wrapping_add(1).max(20000)).parse().unwrap();
+        if TcpStream::connect_timeout(&dead, Duration::from_millis(50)).is_err() {
+            assert!(!port_is_live(&dead));
+        }
+    }
+
+    #[test]
+    fn port_is_live_probes_loopback_when_bound_any() {
+        let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || { let _ = listener.accept(); });
+        let any = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), addr.port());
+        assert!(port_is_live(&any), "should probe 127.0.0.1 when listen is 0.0.0.0");
+    }
+
+    #[test]
+    fn connect_timeout_ironclad() {
+        assert_eq!(
+            connect_timeout(&ScanMode::Ironclad, &Protocol::Masque, &MasqueNoize::Firewall, &WgNoize::Balanced),
+            Duration::from_secs(240)
+        );
+    }
+
+    #[test]
+    fn connect_timeout_gfw_adds_25pct() {
+        assert_eq!(
+            connect_timeout(&ScanMode::Balanced, &Protocol::Masque, &MasqueNoize::Gfw, &WgNoize::Balanced),
+            Duration::from_secs(150 + 150 * 25 / 100)
+        );
+    }
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,7 @@
 use crate::aether::{self, profiles::ConnectionProfile};
 use crate::error::AetherError;
 use crate::state::{AppState, ConnectionState};
+use crate::tray;
 use tauri::{AppHandle, State};
 
 #[tauri::command]
@@ -31,4 +32,14 @@ pub fn get_default_profile(app: AppHandle) -> ConnectionProfile {
 pub fn set_default_profile(app: AppHandle, profile: ConnectionProfile) -> Result<(), AetherError> {
     aether::profiles::save(&app, &profile);
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_close_to_tray() -> bool {
+    tray::get_close_to_tray()
+}
+
+#[tauri::command]
+pub fn set_close_to_tray(app: AppHandle, enabled: bool) {
+    tray::set_close_to_tray(&app, enabled);
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,9 +6,10 @@ mod error;
 mod events;
 mod focus;
 mod state;
+mod tray;
 
 use state::AppState;
-use tauri::Manager;
+use tauri::{Manager, WindowEvent};
 
 fn main() {
     tauri::Builder::default()
@@ -22,6 +23,7 @@ fn main() {
             // same port.
             aether::orphan::reap_orphan(&data_dir);
             focus::spawn_watcher(app.handle().clone());
+            tray::init(app)?;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -30,7 +32,17 @@ fn main() {
             commands::get_status,
             commands::get_default_profile,
             commands::set_default_profile,
+            commands::get_close_to_tray,
+            commands::set_close_to_tray,
         ])
+        .on_window_event(|window, event| {
+            if let WindowEvent::CloseRequested { api, .. } = event {
+                if tray::get_close_to_tray() {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
+        })
         .build(tauri::generate_context!())
         .expect("error building tauri application")
         .run(|app_handle, event| {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,98 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    AppHandle, Manager,
+};
+
+/// Global flag — toggled from the frontend via the `set_close_to_tray` command
+/// and persisted to disk via `tauri-plugin-store`. Using an atomic here instead
+/// of the store directly because the `on_window_event` callback fires on every
+/// close and reading the store there would be wasteful.
+static CLOSE_TO_TRAY: AtomicBool = AtomicBool::new(false);
+
+const STORE_FILE: &str = "settings.json";
+const STORE_KEY: &str = "close_to_tray";
+
+pub fn get_close_to_tray() -> bool {
+    CLOSE_TO_TRAY.load(Ordering::Relaxed)
+}
+
+pub fn set_close_to_tray(app: &AppHandle, enabled: bool) {
+    CLOSE_TO_TRAY.store(enabled, Ordering::Relaxed);
+    // Persist so it survives restarts.
+    use tauri_plugin_store::StoreExt;
+    if let Ok(store) = app.store(STORE_FILE) {
+        store.set(STORE_KEY, serde_json::Value::Bool(enabled));
+        let _ = store.save();
+    }
+}
+
+/// Load persisted preference and sync the atomic.
+fn load_preference(app: &AppHandle) {
+    use tauri_plugin_store::StoreExt;
+    let enabled = app
+        .store(STORE_FILE)
+        .ok()
+        .and_then(|s| s.get(STORE_KEY))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    CLOSE_TO_TRAY.store(enabled, Ordering::Relaxed);
+}
+
+/// Create the system-tray icon, menu, and event handlers. Call from `setup`.
+pub fn init(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    load_preference(app.handle());
+
+    let show = MenuItem::with_id(app, "show", "Show", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show, &quit])?;
+
+    let mut builder = TrayIconBuilder::new()
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .tooltip("Aether-GUI")
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "show" => show_window(app),
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    builder.build(app)?;
+    Ok(())
+}
+
+fn show_window(app: &AppHandle) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.unminimize();
+        let _ = w.show();
+        let _ = w.set_focus();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_flag_round_trips() {
+        CLOSE_TO_TRAY.store(false, Ordering::Relaxed);
+        assert!(!get_close_to_tray());
+        CLOSE_TO_TRAY.store(true, Ordering::Relaxed);
+        assert!(get_close_to_tray());
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion, MotionConfig } from "motion/react";
 import { ConnectButton } from "@/components/ConnectButton";
 import { ConnectionStatusLine } from "@/components/ConnectionStatusLine";
 import { AdvancedPanel } from "@/components/AdvancedPanel";
+import { CloseToTrayToggle } from "@/components/CloseToTrayToggle";
 import { AmbientBackground } from "@/components/AmbientBackground";
 import { SidecarErrorScreen } from "@/components/SidecarErrorScreen";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -24,6 +25,7 @@ function MainScreen() {
         <ConnectionStatusLine />
       </div>
       <AdvancedPanel />
+      <CloseToTrayToggle />
     </div>
   );
 }

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -12,6 +12,7 @@ import { ScanModeToggle } from "@/components/ScanModeToggle";
 import { IpVersionToggle } from "@/components/IpVersionToggle";
 import { MasqueTransportToggle } from "@/components/MasqueTransportToggle";
 import { NoizeProfileToggle } from "@/components/NoizeProfileToggle";
+import { BindAddressField } from "@/components/BindAddressField";
 import { useConnectionStore } from "@/state/connectionStore";
 
 function FieldRow({
@@ -109,6 +110,12 @@ export function AdvancedPanel() {
               tooltip="Disguises the handshake so DPI can't fingerprint the protocol. Heavier profiles send more decoy traffic — try escalating if the default doesn't connect. Options change based on the selected protocol."
             >
               <NoizeProfileToggle />
+            </FieldRow>
+            <FieldRow
+              label="SOCKS5 Proxy"
+              tooltip="The local address Aether's SOCKS5 proxy listens on. Change the port to avoid conflicts, or enable LAN to share the tunnel with other devices on your network."
+            >
+              <BindAddressField />
             </FieldRow>
 
             <div className="flex items-center justify-between">

--- a/src/components/BindAddressField.tsx
+++ b/src/components/BindAddressField.tsx
@@ -1,0 +1,55 @@
+import { useConnectionStore } from "@/state/connectionStore";
+import { Switch } from "@/components/ui/switch";
+
+const DEFAULT_PORT = "1819";
+const LOOPBACK = "127.0.0.1";
+const ANY = "0.0.0.0";
+
+function splitAddr(addr: string): { host: string; port: string } {
+  const last = addr.lastIndexOf(":");
+  if (last === -1) return { host: LOOPBACK, port: addr || DEFAULT_PORT };
+  return { host: addr.slice(0, last) || LOOPBACK, port: addr.slice(last + 1) || DEFAULT_PORT };
+}
+
+export function BindAddressField() {
+  const bind = useConnectionStore((s) => s.profile.bind_address);
+  const setBindAddress = useConnectionStore((s) => s.setBindAddress);
+  const status = useConnectionStore((s) => s.status);
+  const locked = status.state !== "Idle" && status.state !== "Error";
+
+  const { host, port } = splitAddr(bind);
+  const lan = host === ANY;
+
+  const rebuild = (h: string, p: string) =>
+    setBindAddress(`${h}:${p || DEFAULT_PORT}`);
+
+  return (
+    <div className="flex items-center justify-between">
+      <input
+        type="text"
+        inputMode="numeric"
+        value={port}
+        disabled={locked}
+        onChange={(e) => {
+          const v = e.target.value.replace(/\D/g, "").slice(0, 5);
+          rebuild(host, v);
+        }}
+        onBlur={() => {
+          const n = Number(port);
+          if (!port || n < 1 || n > 65535) rebuild(host, DEFAULT_PORT);
+        }}
+        className="h-8 w-20 rounded-md bg-black/20 px-2 text-center text-xs text-foreground ring-1 ring-white/10 outline-none focus:ring-primary disabled:opacity-50"
+        aria-label="SOCKS5 port"
+      />
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">Allow connections from the LAN</span>
+        <Switch
+          checked={lan}
+          onCheckedChange={(on) => rebuild(on ? ANY : LOOPBACK, port)}
+          disabled={locked}
+          aria-label="Allow connections from the LAN"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/CloseToTrayToggle.tsx
+++ b/src/components/CloseToTrayToggle.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Switch } from "@/components/ui/switch";
+
+export function CloseToTrayToggle() {
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    invoke<boolean>("get_close_to_tray").then((v) => {
+      setEnabled(v);
+      setLoaded(true);
+    });
+  }, []);
+
+  if (!loaded) return null;
+
+  return (
+    <div className="flex w-full max-w-sm items-center justify-between px-1 py-2">
+      <span className="text-xs text-muted-foreground">
+        Minimize to system tray
+      </span>
+      <Switch
+        checked={enabled}
+        onCheckedChange={(on) => {
+          setEnabled(on);
+          void invoke("set_close_to_tray", { enabled: on });
+        }}
+        aria-label="Minimize to system tray instead of closing"
+      />
+    </div>
+  );
+}

--- a/src/state/connectionStore.ts
+++ b/src/state/connectionStore.ts
@@ -30,6 +30,7 @@ interface ConnectionState {
   setMasqueHttp2: (masque_http2: boolean) => void;
   setMasqueNoize: (masque_noize: MasqueNoize) => void;
   setWgNoize: (wg_noize: WgNoize) => void;
+  setBindAddress: (bind_address: string) => void;
   retryAfterSidecarError: () => void;
 }
 
@@ -43,6 +44,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     masque_http2: false,
     masque_noize: "firewall",
     wg_noize: "balanced",
+    bind_address: "127.0.0.1:1819",
   },
   logs: [],
   sidecarError: null,
@@ -94,6 +96,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   setWgNoize: (wg_noize) =>
     set((s) => ({ profile: { ...s.profile, wg_noize } })),
+
+  setBindAddress: (bind_address) =>
+    set((s) => ({ profile: { ...s.profile, bind_address } })),
 
   // Clears the fallback screen so the user can attempt Connect again (e.g.
   // after fixing a broken install) — the next connect() call will re-set

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -30,6 +30,8 @@ export interface ConnectionProfile {
   masque_noize: MasqueNoize;
   /** Obfuscation profile for WireGuard/gool (balanced/aggressive/light/off). */
   wg_noize: WgNoize;
+  /** Local SOCKS5 listen address (--bind). Default 127.0.0.1:1819. */
+  bind_address: string;
 }
 
 export interface LogLine {


### PR DESCRIPTION
## Summary

- **SOCKS5 Proxy row** in the Advanced panel: port field (default `1819`) + "Allow connections from the LAN" toggle (`127.0.0.1` ↔ `0.0.0.0`). Port input left-aligned, LAN toggle right-aligned, single row.
- **`--bind` flag** forwarded to Aether only when non-default and a valid `SocketAddr`; old saved profiles get the default via `serde(default)`.
- **System tray**: tray icon with Show/Quit context menu. "Minimize to system tray" toggle at the bottom of the main screen — when ON, the window X button hides to tray instead of closing. Left-click tray icon or right-click → Show restores the window. Quit exits fully and cleans up any running Aether process.
- Tray preference persists across restarts via `tauri-plugin-store` (`settings.json`).
- Cross-platform: Windows (notification area), macOS (menu bar), Linux (appindicator).

## Changes

| File | What |
|---|---|
| `src-tauri/Cargo.toml` | Enable `tray-icon` feature |
| `src-tauri/src/tray.rs` | Tray icon, menu, close-to-tray logic, preference persistence |
| `src-tauri/src/main.rs` | Wire `tray::init`, `on_window_event` close interception, register commands |
| `src-tauri/src/commands.rs` | `get_close_to_tray` / `set_close_to_tray` Tauri commands |
| `src-tauri/capabilities/default.json` | Add `allow-show` / `allow-hide` permissions |
| `src-tauri/src/aether/profiles.rs` | `bind_address` field with `serde(default)`, `--bind` emission in `as_args()` |
| `src-tauri/src/aether/status.rs` | `parse_bind_address`, `probe_addr` (rewrites `0.0.0.0` → `127.0.0.1`), updated `port_is_live` |
| `src-tauri/src/aether/mod.rs` | Use `parse_bind_address` for port-in-use check and liveness monitoring |
| `src/components/BindAddressField.tsx` | Port input + LAN toggle component |
| `src/components/CloseToTrayToggle.tsx` | Minimize to system tray toggle component |
| `src/App.tsx` | Add `CloseToTrayToggle` to main screen |
| `src/components/AdvancedPanel.tsx` | Add SOCKS5 Proxy field row |
| `src/state/connectionStore.ts` | `setBindAddress` action, `bind_address` in default profile |
| `src/types/connection.ts` | `bind_address` field in `ConnectionProfile` |

## Test plan

- [x] 18 Rust unit tests pass (`cargo test`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] `cargo build` succeeds (only pre-existing `Emitter` warning in `focus.rs`)
- [x] GUI verified via WSLg — bind address row renders correctly
- [x] Close-to-tray code path verified: OFF → normal close, ON → hide + tray restore + Quit cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)