### PR TITLE
Feat/tray connection status badge

### DIFF
--- a/src-tauri/src/aether/mod.rs
+++ b/src-tauri/src/aether/mod.rs
@@ -7,6 +7,7 @@ pub mod status;
 use crate::error::AetherError;
 use crate::events::{now_millis, LogEvent, LOG_EVENT, STATUS_EVENT};
 use crate::state::ConnectionState;
+use crate::tray;
 use profiles::ConnectionProfile;
 use pty::PtySession;
 use std::path::{Path, PathBuf};
@@ -69,6 +70,7 @@ fn resolve_binary(app: &AppHandle) -> Result<PathBuf, AetherError> {
 
 fn set_state_and_emit(app: &AppHandle, manager: &Arc<Mutex<AetherManager>>, new_state: ConnectionState) {
     manager.lock().unwrap().state = new_state.clone();
+    tray::set_visual_state(app, &new_state);
     let _ = app.emit(STATUS_EVENT, &new_state);
 }
 
@@ -111,6 +113,7 @@ pub fn start_connect(
         // independent of whatever happened on a previous, unrelated attempt.
         mgr.retry_count = 0;
     }
+    tray::set_visual_state(&app, &ConnectionState::Launching);
     let _ = app.emit(STATUS_EVENT, &ConnectionState::Launching);
 
     spawn_and_monitor(app, manager, binary, data_dir, profile)
@@ -277,6 +280,7 @@ fn monitor_connect(
                 mgr.state = ConnectionState::Connecting;
                 let new_state = mgr.state.clone();
                 drop(mgr);
+                tray::set_visual_state(&app, &new_state);
                 let _ = app.emit(STATUS_EVENT, &new_state);
                 announced_connecting = true;
                 continue;
@@ -293,6 +297,7 @@ fn monitor_connect(
             // rather than inheriting whatever it took to get here.
             mgr.retry_count = 0;
             drop(mgr);
+            tray::set_visual_state(&app, &new_state);
             let _ = app.emit(STATUS_EVENT, &new_state);
             // Only persisted as "last successful" once actually proven to
             // work, never on a mere attempt (see profiles::save's doc-comment).

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,5 +1,7 @@
+use crate::state::ConnectionState;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{
+    image::Image,
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Manager,
@@ -13,6 +15,7 @@ static CLOSE_TO_TRAY: AtomicBool = AtomicBool::new(false);
 
 const STORE_FILE: &str = "settings.json";
 const STORE_KEY: &str = "close_to_tray";
+const TRAY_ID: &str = "aether-main";
 
 pub fn get_close_to_tray() -> bool {
     CLOSE_TO_TRAY.load(Ordering::Relaxed)
@@ -40,6 +43,81 @@ fn load_preference(app: &AppHandle) {
     CLOSE_TO_TRAY.store(enabled, Ordering::Relaxed);
 }
 
+fn visual_for_state(state: &ConnectionState) -> ([u8; 3], &'static str) {
+    match state {
+        ConnectionState::Connected { .. } => ([52, 211, 153], "Connected"),
+        ConnectionState::Launching
+        | ConnectionState::Connecting
+        | ConnectionState::Reconnecting { .. }
+        | ConnectionState::Disconnecting => ([249, 115, 22], "Working"),
+        ConnectionState::Error { .. } => ([239, 68, 68], "Connection error"),
+        ConnectionState::Idle => ([148, 163, 184], "Disconnected"),
+    }
+}
+
+fn status_badged_icon(base: &Image<'_>, color: [u8; 3]) -> Image<'static> {
+    let width = base.width() as i32;
+    let height = base.height() as i32;
+    let mut rgba = base.rgba().to_vec();
+
+    if width <= 0 || height <= 0 {
+        return Image::new_owned(rgba, base.width(), base.height());
+    }
+
+    // Preserve the original artwork and add a small high-contrast status dot.
+    // Tray icons are commonly rendered at 16–24 px, so derive the badge size
+    // from the source icon instead of assuming a fixed output resolution.
+    let shortest = width.min(height);
+    let radius = (shortest / 6).max(2);
+    let border = (radius / 3).max(1);
+    let margin = (shortest / 18).max(1);
+    let center_x = width - radius - margin;
+    let center_y = height - radius - margin;
+    let outer_radius = radius + border;
+
+    for y in (center_y - outer_radius).max(0)..=(center_y + outer_radius).min(height - 1) {
+        for x in (center_x - outer_radius).max(0)..=(center_x + outer_radius).min(width - 1) {
+            let dx = x - center_x;
+            let dy = y - center_y;
+            let distance_squared = dx * dx + dy * dy;
+            let pixel_index = ((y * width + x) * 4) as usize;
+
+            if distance_squared <= outer_radius * outer_radius {
+                if distance_squared > radius * radius {
+                    // A dark outline keeps the badge legible over both light
+                    // and dark regions of the existing icon artwork.
+                    rgba[pixel_index] = 22;
+                    rgba[pixel_index + 1] = 24;
+                    rgba[pixel_index + 2] = 29;
+                    rgba[pixel_index + 3] = 255;
+                } else {
+                    rgba[pixel_index] = color[0];
+                    rgba[pixel_index + 1] = color[1];
+                    rgba[pixel_index + 2] = color[2];
+                    rgba[pixel_index + 3] = 255;
+                }
+            }
+        }
+    }
+
+    Image::new_owned(rgba, base.width(), base.height())
+}
+
+/// Update the tray icon and tooltip to mirror the backend connection state.
+/// Keeping this in Rust means the tray remains accurate even while the main
+/// window is hidden and does not depend on a frontend listener staying mounted.
+pub fn set_visual_state(app: &AppHandle, state: &ConnectionState) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    let Some(base) = app.default_window_icon() else {
+        return;
+    };
+    let (color, label) = visual_for_state(state);
+    let _ = tray.set_icon(Some(status_badged_icon(base, color)));
+    let _ = tray.set_tooltip(Some(format!("Aether-GUI — {label}")));
+}
+
 /// Create the system-tray icon, menu, and event handlers. Call from `setup`.
 pub fn init(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     load_preference(app.handle());
@@ -48,10 +126,10 @@ pub fn init(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&show, &quit])?;
 
-    let mut builder = TrayIconBuilder::new()
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
         .menu(&menu)
         .show_menu_on_left_click(false)
-        .tooltip("Aether-GUI")
+        .tooltip("Aether-GUI — Disconnected")
         .on_menu_event(|app, event| match event.id.as_ref() {
             "show" => show_window(app),
             "quit" => app.exit(0),
@@ -69,7 +147,7 @@ pub fn init(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         });
 
     if let Some(icon) = app.default_window_icon() {
-        builder = builder.icon(icon.clone());
+        builder = builder.icon(status_badged_icon(icon, [148, 163, 184]));
     }
 
     builder.build(app)?;
@@ -94,5 +172,27 @@ mod tests {
         assert!(!get_close_to_tray());
         CLOSE_TO_TRAY.store(true, Ordering::Relaxed);
         assert!(get_close_to_tray());
+    }
+
+    #[test]
+    fn tray_visuals_cover_connection_lifecycle() {
+        assert_eq!(visual_for_state(&ConnectionState::Idle).1, "Disconnected");
+        assert_eq!(visual_for_state(&ConnectionState::Connecting).1, "Working");
+        assert_eq!(
+            visual_for_state(&ConnectionState::Connected {
+                socks_addr: "127.0.0.1:1819".into(),
+                connected_at_ms: 0,
+            })
+            .1,
+            "Connected"
+        );
+        assert_eq!(
+            visual_for_state(&ConnectionState::Error {
+                message: "test".into(),
+                phase: "test".into(),
+            })
+            .1,
+            "Connection error"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Make the existing system-tray icon reflect Aether-GUI's backend connection state while preserving the original icon artwork.

The implementation adds a small high-contrast status badge in the lower-right corner and updates the tray tooltip alongside it.

## Behavior

- gray badge — disconnected / `Idle`
- orange badge — launching, connecting, reconnecting, or disconnecting
- green badge — connected
- red badge — terminal connection error

## Changes

- assign a stable ID to the existing tray icon so it can be updated in place
- derive badge size from the source icon dimensions so it remains visible at typical tray sizes
- preserve the existing artwork and draw only a small outlined status dot
- update the tooltip to `Disconnected`, `Working`, `Connected`, or `Connection error`
- sync the tray directly from backend connection-state transitions, including when the main window is hidden
- add focused tests for lifecycle-to-visual mapping

## Why

When the app is minimized to the tray, users should be able to tell at a glance whether the tunnel is connected, working, disconnected, or in an error state without reopening the window.

Keeping the synchronization in Rust avoids depending on a frontend listener or window visibility for tray correctness.

## Scope

This PR only visualizes the existing connection state. It does not change the state machine, retry behavior, connection logic, protocol selection, or tunnel implementation.

## Validation

- compared against upstream `main` at `9ba2ef0`: two Rust files changed
- manually traced all existing status-emission paths to ensure tray updates cover Launching, Connecting, Connected, Reconnecting, Disconnecting, Idle, and Error
- added tests for the state-to-tooltip/status mapping

A Rust toolchain was not available in the connector environment used to prepare this branch, so `cargo fmt`, `cargo clippy`, and Rust tests still need to be run before marking the PR ready.