### PR TITLE
Build/verify bundled aether resource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
           Expand-Archive aether.zip -DestinationPath aether-extract
           Move-Item aether-extract/aether.exe src-tauri/binaries/aether.exe
 
+      - name: Verify bundled Aether resource
+        run: node scripts/verify-bundled-aether.mjs
+
       - run: npm ci
 
       - uses: tauri-apps/tauri-action@v0

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit",
+    "verify:bundled-aether": "node scripts/verify-bundled-aether.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/scripts/verify-bundled-aether.mjs
+++ b/scripts/verify-bundled-aether.mjs
@@ -1,0 +1,35 @@
+import { access, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const tauriDir = path.join(repoRoot, "src-tauri");
+const configPath = path.join(tauriDir, "tauri.conf.json");
+const binaryName = process.platform === "win32" ? "aether.exe" : "aether";
+const binaryPath = path.join(tauriDir, "binaries", binaryName);
+
+async function main() {
+  await access(binaryPath);
+  const binaryStat = await stat(binaryPath);
+  if (!binaryStat.isFile() || binaryStat.size <= 0) {
+    throw new Error(`Bundled Aether binary is missing or empty: ${binaryPath}`);
+  }
+
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  const resources = config?.bundle?.resources;
+  if (!Array.isArray(resources) || !resources.includes("binaries/*")) {
+    throw new Error(
+      'Tauri bundle.resources must include "binaries/*" so the Aether core ships with installers.',
+    );
+  }
+
+  console.log(
+    `Bundled Aether resource verified: ${path.relative(repoRoot, binaryPath)} (${binaryStat.size} bytes)`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Fail the build early when the Aether executable is missing/empty or when the Tauri resource configuration no longer includes the binaries directory.

## Problem

A desktop bundle can otherwise progress into packaging with a broken core-resource setup and only fail later on a clean machine, where the application cannot resolve the bundled Aether binary.

Because the release workflow already fetches the core before packaging, this is a natural point to assert the packaging contract explicitly.

## Changes

- add `scripts/verify-bundled-aether.mjs`
- verify the platform-appropriate core exists (`aether.exe` on Windows, `aether` elsewhere)
- verify the core is a non-empty file
- parse `src-tauri/tauri.conf.json` and verify `bundle.resources` contains `binaries/*`
- expose the check as `npm run verify:bundled-aether`
- run the check in the build workflow immediately after core preparation and before packaging

## Why

This converts a clean-machine runtime failure into a deterministic build-time failure with a direct error message. It also guards against accidental changes to the Tauri resource glob that would silently stop shipping the core.

## Scope

This PR only validates the existing bundled-core contract. It does not change how the core is downloaded, selected, executed, or updated.

## Validation

- compared against upstream `main` at `9ba2ef0`: three focused files changed
- `node --check scripts/verify-bundled-aether.mjs`: passed in an equivalent fixture
- functional fixture with a non-empty platform core plus `bundle.resources: ["binaries/*"]`: passed
- manually reviewed the failure conditions for missing/empty core and missing resource glob

The full repository checks were not executable from the connector environment. Also note that this branch independently touches `build.yml`; if the Windows fetch-helper PR merges first, rebase this branch onto the new upstream `main` before submitting/merging it.