### PR TITLE
fix: surface connection failures in live logs

### DIFF
--- a/src/state/connectionStore.ts
+++ b/src/state/connectionStore.ts
@@ -61,8 +61,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // SidecarErrorScreen instead of the button's own error state.
       if (message.toLowerCase().includes("binary not found")) {
         set({ sidecarError: message });
+        appendRuntimeLog(`[error:core] ${message}`);
       } else {
         set({ status: { state: "Error", message, phase: "launching" } });
+        appendRuntimeLog(`[error:launching] ${message}`);
       }
     }
   },
@@ -106,6 +108,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   retryAfterSidecarError: () => set({ sidecarError: null }),
 }));
 
+function appendRuntimeLog(line: string): void {
+  useConnectionStore.setState((state) => {
+    if (state.logs.at(-1)?.line === line) return state;
+    return {
+      logs: [...state.logs, { line, timestamp: Date.now() }].slice(-MAX_LOG_LINES),
+    };
+  });
+}
+
 // Dev-only: lets the 3D backdrop's per-state moods be driven from the WebView2
 // devtools console without a live tunnel, e.g.
 //   __conn.setState({ status: { state: "Connecting" } })
@@ -145,6 +156,9 @@ export async function initConnectionListeners(): Promise<() => void> {
         // Fresh attempt — last attempt's budget no longer applies.
         ...(e.payload.state === "Launching" ? { scanBudgetSecs: null } : {}),
       });
+      if (e.payload.state === "Error") {
+        appendRuntimeLog(`[error:${e.payload.phase}] ${e.payload.message}`);
+      }
     }),
     listen<LogLine>("aether://log", (e) => {
       pendingLogs.push(e.payload);
@@ -162,6 +176,9 @@ export async function initConnectionListeners(): Promise<() => void> {
       invoke<ConnectionProfile>("get_default_profile"),
     ]);
     useConnectionStore.setState({ status, profile });
+    if (status.state === "Error") {
+      appendRuntimeLog(`[error:${status.phase}] ${status.message}`);
+    }
   } catch (e) {
     console.error("Failed to load initial connection state:", e);
   }


### PR DESCRIPTION
## Summary

Ensure connection failures are visible in the same live log stream users inspect when diagnosing a failed connection.

Currently, synchronous `connect` failures and backend `Error` status events update the visible connection state, but they are not appended to `logs`. This can leave the log panel empty even though the UI reports a failure, which makes transient startup/core errors difficult to diagnose.

This PR keeps the existing state/error behavior unchanged and only mirrors those failures into the bounded runtime log buffer.

## Changes

- append missing-core errors as `[error:core] ...`
- append synchronous launch errors as `[error:launching] ...`
- append backend `Error` status events using their actual phase
- append an existing error when runtime state is reconciled after the window opens/reopens
- avoid immediately duplicating the same synthetic error line
- preserve the existing `MAX_LOG_LINES` bound

## Why

The backend log event stream only contains lines emitted by the Aether process. Failures that happen before the process starts, or errors represented only by a connection-status event, therefore never reach the live log panel. Recording these frontend/runtime failures alongside process logs gives users one consistent place to inspect what went wrong without changing the backend IPC contract.

## Scope

This is intentionally a focused frontend-only change. It does not alter Aether tunnel behavior, protocol handling, route discovery, retry policy, or process supervision.

## Validation

- compared against upstream `main` at `9ba2ef0`: one commit, one changed file
- ran a targeted strict TypeScript compile of the modified store against the current upstream connection types and typed Tauri/Zustand stubs: passed
- manually reviewed the code paths for:
  - missing sidecar/core error
  - synchronous launch failure
  - backend `Error` status event
  - initial/reopened-window state reconciliation
  - duplicate suppression for consecutive identical synthetic error lines

The full repository `npm run typecheck`, `npm run lint`, `npm run build`, and Rust checks were not executable from the connector environment used to prepare this branch. Please keep the PR as draft until the repository-level checks have been run locally.