### PR TITLE
Build/windows aether fetch helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,21 +58,10 @@ jobs:
           AETHER_ASSET: ${{ matrix.aether_asset }}
         run: bash src-tauri/binaries/fetch-aether.sh
 
-      # fetch-aether.sh is unix-only (tar.gz assets); the Windows asset is a
-      # zip, fetched here with the same version pin and checksum verification.
       - name: Fetch Aether core (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: |
-          $pin = (Select-String -Path src-tauri/binaries/fetch-aether.sh -Pattern 'AETHER_VERSION="(.+)"').Matches[0].Groups[1].Value
-          $base = "https://github.com/CluvexStudio/Aether/releases/download/$pin"
-          curl.exe -sL -o aether.zip "$base/aether-windows-x86_64.zip"
-          curl.exe -sL -o SHA256SUMS.txt "$base/SHA256SUMS.txt"
-          $expected = ((Get-Content SHA256SUMS.txt | Select-String 'aether-windows-x86_64.zip') -split '\s+')[0]
-          $actual = (Get-FileHash aether.zip -Algorithm SHA256).Hash.ToLower()
-          if ($actual -ne $expected) { throw "Checksum mismatch: $actual != $expected" }
-          Expand-Archive aether.zip -DestinationPath aether-extract
-          Move-Item aether-extract/aether.exe src-tauri/binaries/aether.exe
+        run: ./src-tauri/binaries/fetch-aether.ps1
 
       - run: npm ci
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,21 @@ Windows x64 only for now — see [Building from source](#building-from-source) f
 
 3. **Fetch the Aether binary**
 
-   Aether-GUI bundles the real `aether` binary from [CluvexStudio/Aether releases](https://github.com/CluvexStudio/Aether/releases) rather than building it — this repo only ships the GUI. Fetch and checksum-verify it for your platform:
+   Aether-GUI bundles the real `aether` binary from [CluvexStudio/Aether releases](https://github.com/CluvexStudio/Aether/releases) rather than building it — this repo only ships the GUI. Fetch and checksum-verify the pinned release for your platform:
+
+   Linux/macOS:
 
    ```sh
    ./src-tauri/binaries/fetch-aether.sh
    ```
 
-   This script covers Linux and macOS directly. On Windows, download the matching `aether-windows-*.zip` from the [Aether releases page](https://github.com/CluvexStudio/Aether/releases) yourself, verify it against the published `SHA256SUMS.txt`, and extract `aether.exe` into `src-tauri/binaries/`.
+   Windows PowerShell:
+
+   ```powershell
+   ./src-tauri/binaries/fetch-aether.ps1
+   ```
+
+   Both helpers verify the downloaded release asset against Aether's published `SHA256SUMS.txt` before placing the executable in `src-tauri/binaries/`.
 
 4. **Run in development mode**
 

--- a/README_fa.md
+++ b/README_fa.md
@@ -58,13 +58,21 @@
 
 ۳. **گرفتن فایل باینری Aether**
 
-   Aether-GUI فایل واقعیِ `aether` را از [ریلیزهای CluvexStudio/Aether](https://github.com/CluvexStudio/Aether/releases) کنار خودش قرار می‌دهد و خودش نمی‌سازدش — این مخزن فقط رابط گرافیکی است. برای سیستم‌عاملتان بگیریدش (با بررسی checksum):
+   Aether-GUI فایل واقعیِ `aether` را از [ریلیزهای CluvexStudio/Aether](https://github.com/CluvexStudio/Aether/releases) کنار خودش قرار می‌دهد و خودش نمی‌سازدش — این مخزن فقط رابط گرافیکی است. نسخه‌ی پین‌شده را برای سیستم‌عاملتان بگیرید و checksum آن را بررسی کنید:
+
+   لینوکس/macOS:
 
    ```sh
    ./src-tauri/binaries/fetch-aether.sh
    ```
 
-   این اسکریپت لینوکس و macOS را مستقیم پوشش می‌دهد. روی ویندوز، فایلِ `aether-windows-*.zip` مناسب را خودتان از [صفحه‌ی ریلیزهای Aether](https://github.com/CluvexStudio/Aether/releases) دانلود کنید، با `SHA256SUMS.txt` منتشرشده بررسی‌اش کنید و `aether.exe` را داخل `src-tauri/binaries/` استخراج کنید.
+   ویندوز PowerShell:
+
+   ```powershell
+   ./src-tauri/binaries/fetch-aether.ps1
+   ```
+
+   هر دو اسکریپت فایل دانلودشده را پیش از قرار دادن فایل اجرایی در `src-tauri/binaries/` با `SHA256SUMS.txt` منتشرشده‌ی Aether بررسی می‌کنند.
 
 ۴. **اجرا در حالت توسعه**
 

--- a/src-tauri/binaries/fetch-aether.ps1
+++ b/src-tauri/binaries/fetch-aether.ps1
@@ -1,0 +1,90 @@
+param(
+    [string]$DestDir = $PSScriptRoot
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$AetherVersion = "v1.3.0"
+$Repo = "CluvexStudio/Aether"
+$AssetName = "aether-windows-x86_64.zip"
+$BaseUrl = "https://github.com/$Repo/releases/download/$AetherVersion"
+
+# Windows PowerShell 5.1 can otherwise negotiate an obsolete TLS version on
+# older machines. GitHub requires modern TLS.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Invoke-DownloadWithRetry {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$OutFile,
+        [int]$Attempts = 3
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            Remove-Item $OutFile -Force -ErrorAction SilentlyContinue
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing -TimeoutSec 90
+            if (-not (Test-Path $OutFile) -or (Get-Item $OutFile).Length -le 0) {
+                throw "Downloaded file is empty: $OutFile"
+            }
+            return
+        }
+        catch {
+            Remove-Item $OutFile -Force -ErrorAction SilentlyContinue
+            if ($attempt -eq $Attempts) {
+                throw
+            }
+            Start-Sleep -Seconds (2 * $attempt)
+        }
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $DestDir | Out-Null
+
+$TempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("aether-gui-fetch-" + [guid]::NewGuid().ToString("N"))
+$ArchivePath = Join-Path $TempDir $AssetName
+$SumsPath = Join-Path $TempDir "SHA256SUMS.txt"
+$ExtractDir = Join-Path $TempDir "extract"
+$Target = Join-Path $DestDir "aether.exe"
+
+New-Item -ItemType Directory -Force -Path $TempDir, $ExtractDir | Out-Null
+
+try {
+    Write-Host "Downloading Aether $AetherVersion ($AssetName)..."
+    Invoke-DownloadWithRetry -Uri "$BaseUrl/$AssetName" -OutFile $ArchivePath
+    Invoke-DownloadWithRetry -Uri "$BaseUrl/SHA256SUMS.txt" -OutFile $SumsPath
+
+    $ChecksumLine = Get-Content $SumsPath |
+        Where-Object { $_ -match ("\s" + [regex]::Escape($AssetName) + "$") } |
+        Select-Object -First 1
+    if (-not $ChecksumLine) {
+        throw "No checksum entry found for $AssetName"
+    }
+
+    $Expected = ($ChecksumLine -split "\s+")[0].ToLowerInvariant()
+    $Actual = (Get-FileHash $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($Actual -ne $Expected) {
+        throw "Checksum mismatch for $AssetName`: $Actual != $Expected"
+    }
+
+    Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+    $DownloadedExe = Get-ChildItem -Path $ExtractDir -Recurse -Filter "aether.exe" | Select-Object -First 1
+    if (-not $DownloadedExe -or $DownloadedExe.Length -le 0) {
+        throw "aether.exe was not found or is empty inside $AssetName"
+    }
+
+    $TemporaryTarget = "$Target.new"
+    Remove-Item $TemporaryTarget -Force -ErrorAction SilentlyContinue
+    Copy-Item $DownloadedExe.FullName $TemporaryTarget -Force
+    if ((Get-Item $TemporaryTarget).Length -le 0) {
+        throw "Prepared Aether binary is empty"
+    }
+
+    Remove-Item $Target -Force -ErrorAction SilentlyContinue
+    Move-Item $TemporaryTarget $Target -Force
+    Write-Host "Aether binary ready at $Target (SHA-256 verified)"
+}
+finally {
+    Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Add a first-class PowerShell helper for fetching the pinned Aether core on Windows and reuse that helper in the Windows build job.

This removes duplicated inline download logic from CI and gives Windows contributors the same one-command, checksum-verified setup path already available to Linux/macOS contributors.

## Problem

The repository currently has a reusable Unix fetch helper, while Windows setup is split between:

- manual download instructions for local development; and
- a separate inline PowerShell implementation embedded in the GitHub Actions workflow.

That duplication makes the Windows local-development and release-build paths easier to drift apart.

## Changes

- add `src-tauri/binaries/fetch-aether.ps1`
- keep the helper pinned to the repository's current Aether release (`v1.3.0`)
- enable TLS 1.2 for compatibility with Windows PowerShell 5.1 on older systems
- retry transient downloads with bounded backoff
- download both the Windows x64 archive and the published `SHA256SUMS.txt`
- verify SHA-256 before extracting or replacing the local executable
- stage the prepared executable before replacing `aether.exe`, so failed downloads/checks do not overwrite the existing binary
- clean up temporary download/extraction files
- replace the duplicated inline Windows download block in `.github/workflows/build.yml` with the helper call
- update English and Persian build instructions to document both platform-specific helpers

## Why

The same core-preparation logic should be reusable by local development and CI. Keeping checksum verification in one Windows helper reduces duplicated release plumbing and makes clean Windows setup less error-prone.

## Scope

This is build/setup tooling only. It does not introduce runtime core updates, change the pinned Aether version, or modify any tunnel/protocol behavior.

## Validation

- compared against upstream `main` at `9ba2ef0`: four focused files changed
- reviewed the helper against the existing pinned Unix fetch flow and the current Windows CI checksum-verification behavior
- verified that CI still fetches the Aether core before dependency installation and Tauri packaging

PowerShell was not available in the connector environment used to prepare this branch, so the helper has not been executed there. Please run the repository checks and exercise `fetch-aether.ps1` on Windows before marking the PR ready.