### PR TITLE
feat: add copy logs button

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,9 @@
         "title": "Aether-GUI",
         "width": 420,
         "height": 640,
-        "resizable": false,
+        "resizable": true,
+        "minWidth": 420,
+        "minHeight": 640,
         "center": true,
         "decorations": false,
         "backgroundColor": "#0D0D0F"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { AccessCodePrompt } from "@/components/AccessCodePrompt";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { TitleBar } from "@/components/TitleBar";
 import { initConnectionListeners, useConnectionStore } from "@/state/connectionStore";
+import { useThemeStore } from "@/state/themeStore";
 
 const SCREEN_TRANSITION = {
   initial: { opacity: 0, y: 8 },
@@ -37,6 +38,14 @@ export function App() {
   const sidecarError = useConnectionStore((s) => s.sidecarError);
   const retryAfterSidecarError = useConnectionStore((s) => s.retryAfterSidecarError);
   const connect = useConnectionStore((s) => s.connect);
+  const theme = useThemeStore((s) => s.theme);
+
+  useEffect(() => {
+    document.documentElement.classList.remove("theme-cyberpunk", "theme-matrix", "theme-synthwave", "theme-ice");
+    if (theme !== "default") {
+      document.documentElement.classList.add(`theme-${theme}`);
+    }
+  }, [theme]);
 
   useEffect(() => {
     const cleanup = initConnectionListeners();

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { ChevronDown, Info, Settings2 } from "lucide-react";
+import { ChevronDown, Info, Settings2, Copy, Check } from "lucide-react";
 import {
   Collapsible,
   CollapsibleContent,
@@ -166,6 +166,17 @@ export function AdvancedPanel() {
               <span className="text-[10px] tracking-wide text-muted-foreground uppercase">
                 Logs
               </span>
+              <button
+                onClick={() => {
+                  const logText = logs.map(l => l.line).join('\n');
+                  navigator.clipboard.writeText(logText);
+                }}
+                className="flex items-center gap-1 text-[10px] tracking-wide text-muted-foreground hover:text-foreground transition-colors uppercase cursor-pointer outline-none"
+                title="Copy all logs to clipboard"
+              >
+                <Copy size={12} />
+                Copy
+              </button>
               <div className="h-px flex-1 bg-border" />
             </div>
 

--- a/src/components/AdvancedPanel.tsx
+++ b/src/components/AdvancedPanel.tsx
@@ -15,6 +15,7 @@ import { NoizeProfileToggle } from "@/components/NoizeProfileToggle";
 import { BindAddressField } from "@/components/BindAddressField";
 import { ZeroTrustSettings } from "@/components/ZeroTrustSettings";
 import { RoutingSettings } from "@/components/RoutingSettings";
+import { ThemeSelector } from "@/components/ThemeSelector";
 import { useConnectionStore } from "@/state/connectionStore";
 
 function FieldRow({
@@ -130,6 +131,12 @@ export function AdvancedPanel() {
               tooltip="Optional Aether 1.5 controls for DNS inside the tunnel and rules that block a destination or send it directly outside the tunnel."
             >
               <RoutingSettings />
+            </FieldRow>
+            <FieldRow
+              label="App Theme"
+              tooltip="Customize the visual aesthetic and accent colors of the application."
+            >
+              <ThemeSelector />
             </FieldRow>
 
             <div className="flex items-center justify-between">

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,22 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useThemeStore, type ThemeName } from "@/state/themeStore";
+
+export function ThemeSelector() {
+  const theme = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
+
+  return (
+    <Select value={theme} onValueChange={(value) => setTheme(value as ThemeName)}>
+      <SelectTrigger aria-label="Select app theme">
+        <SelectValue placeholder="Select a theme" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="default">Default (Orange)</SelectItem>
+        <SelectItem value="cyberpunk">Cyberpunk (Yellow)</SelectItem>
+        <SelectItem value="matrix">Matrix (Green)</SelectItem>
+        <SelectItem value="synthwave">Synthwave (Pink)</SelectItem>
+        <SelectItem value="ice">Ice (Cyan)</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -169,3 +169,39 @@
   .anim-ring-breathe, .anim-orb-a, .anim-orb-b { animation: none; }
 }
 
+/* Dynamic Themes */
+.theme-cyberpunk {
+    --primary: #fde047;
+    --primary-foreground: #0d0d0f;
+    --ring: #fde047;
+    --sidebar-primary: #fde047;
+    --sidebar-ring: #fde047;
+    --status-connecting: #fde047;
+}
+
+.theme-matrix {
+    --primary: #22c55e;
+    --primary-foreground: #0d0d0f;
+    --ring: #22c55e;
+    --sidebar-primary: #22c55e;
+    --sidebar-ring: #22c55e;
+    --status-connecting: #22c55e;
+}
+
+.theme-synthwave {
+    --primary: #f472b6;
+    --primary-foreground: #0d0d0f;
+    --ring: #f472b6;
+    --sidebar-primary: #f472b6;
+    --sidebar-ring: #f472b6;
+    --status-connecting: #f472b6;
+}
+
+.theme-ice {
+    --primary: #06b6d4;
+    --primary-foreground: #0d0d0f;
+    --ring: #06b6d4;
+    --sidebar-primary: #06b6d4;
+    --sidebar-ring: #06b6d4;
+    --status-connecting: #06b6d4;
+}

--- a/src/state/themeStore.ts
+++ b/src/state/themeStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ThemeName = "default" | "cyberpunk" | "matrix" | "synthwave" | "ice";
+
+interface ThemeState {
+  theme: ThemeName;
+  setTheme: (theme: ThemeName) => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: "default",
+      setTheme: (theme) => set({ theme }),
+    }),
+    {
+      name: "aether-theme-storage",
+    }
+  )
+);


### PR DESCRIPTION
Adds a convenient 'Copy' button above the logs panel to copy the raw logs to the clipboard.