### PR TITLE
chore: make the CONTRIBUTING gate pass on main

### DIFF
--- a/src-tauri/src/aether/profiles.rs
+++ b/src-tauri/src/aether/profiles.rs
@@ -302,6 +302,68 @@ impl ConnectionProfile {
     }
 }
 
+impl Default for ConnectionProfile {
+    fn default() -> Self {
+        // Mirrors Aether's own defaults.
+        Self {
+            protocol: Protocol::Auto,
+            scan_mode: ScanMode::Balanced,
+            ip_version: IpVersion::V4,
+            quick_reconnect: true,
+            masque_http2: false,
+            masque_noize: MasqueNoize::Firewall,
+            wg_noize: WgNoize::Balanced,
+            bind_address: default_bind_address(),
+            dns: String::new(),
+            zero_trust_team: String::new(),
+            zero_trust_auth: ZeroTrustAuth::Email,
+            access_email: String::new(),
+            access_client_id: String::new(),
+            access_client_secret: String::new(),
+            access_token: String::new(),
+            zero_trust_gateway: false,
+            route_block: String::new(),
+            route_direct: String::new(),
+            routes_file: String::new(),
+        }
+    }
+}
+
+const STORE_FILE: &str = "profile.json";
+const STORE_KEY: &str = "last_successful_profile";
+
+/// Loads the last profile that reached `Connected`, or the hardcoded default
+/// on first run. Only ever written by `save()` at the moment a connection
+/// actually succeeds (see aether/mod.rs) — never on a mere attempt, so a bad
+/// guess can't poison future one-click connects.
+pub fn load(app: &tauri::AppHandle) -> ConnectionProfile {
+    use tauri_plugin_store::StoreExt;
+    app.store(STORE_FILE)
+        .ok()
+        .and_then(|s| s.get(STORE_KEY))
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default()
+}
+
+pub fn save(app: &tauri::AppHandle, profile: &ConnectionProfile) {
+    use tauri_plugin_store::StoreExt;
+    if let Ok(store) = app.store(STORE_FILE) {
+        // A successful connection profile is useful to remember, but Access
+        // credentials are not. Leave them in process memory only; the next
+        // app launch will ask for them again rather than writing a JWT,
+        // service secret or email address into profile.json.
+        let mut persisted = profile.clone();
+        persisted.access_email.clear();
+        persisted.access_client_id.clear();
+        persisted.access_client_secret.clear();
+        persisted.access_token.clear();
+        if let Ok(value) = serde_json::to_value(persisted) {
+            store.set(STORE_KEY, value);
+            let _ = store.save();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -315,8 +377,10 @@ mod tests {
 
     #[test]
     fn custom_port_emits_bind() {
-        let mut p = ConnectionProfile::default();
-        p.bind_address = "127.0.0.1:1919".into();
+        let p = ConnectionProfile {
+            bind_address: "127.0.0.1:1919".into(),
+            ..Default::default()
+        };
         let args = p.as_args();
         let i = args
             .iter()
@@ -327,8 +391,10 @@ mod tests {
 
     #[test]
     fn lan_bind_emits_bind() {
-        let mut p = ConnectionProfile::default();
-        p.bind_address = "0.0.0.0:1819".into();
+        let p = ConnectionProfile {
+            bind_address: "0.0.0.0:1819".into(),
+            ..Default::default()
+        };
         let args = p.as_args();
         let i = args
             .iter()
@@ -339,8 +405,10 @@ mod tests {
 
     #[test]
     fn lan_with_custom_port_emits_bind() {
-        let mut p = ConnectionProfile::default();
-        p.bind_address = "0.0.0.0:9999".into();
+        let p = ConnectionProfile {
+            bind_address: "0.0.0.0:9999".into(),
+            ..Default::default()
+        };
         let args = p.as_args();
         let i = args
             .iter()
@@ -351,8 +419,10 @@ mod tests {
 
     #[test]
     fn invalid_bind_is_not_forwarded() {
-        let mut p = ConnectionProfile::default();
-        p.bind_address = "127.0.0.1:".into();
+        let p = ConnectionProfile {
+            bind_address: "127.0.0.1:".into(),
+            ..Default::default()
+        };
         let args = p.as_args();
         assert!(!args.iter().any(|a| a == "--bind"), "args={args:?}");
     }
@@ -422,67 +492,5 @@ mod tests {
             Some(("AETHER_ACCESS_EMAIL", "me@example.com"))
         );
         assert!(!p.as_args().iter().any(|arg| arg.contains("me@example.com")));
-    }
-}
-
-impl Default for ConnectionProfile {
-    fn default() -> Self {
-        // Mirrors Aether's own defaults.
-        Self {
-            protocol: Protocol::Auto,
-            scan_mode: ScanMode::Balanced,
-            ip_version: IpVersion::V4,
-            quick_reconnect: true,
-            masque_http2: false,
-            masque_noize: MasqueNoize::Firewall,
-            wg_noize: WgNoize::Balanced,
-            bind_address: default_bind_address(),
-            dns: String::new(),
-            zero_trust_team: String::new(),
-            zero_trust_auth: ZeroTrustAuth::Email,
-            access_email: String::new(),
-            access_client_id: String::new(),
-            access_client_secret: String::new(),
-            access_token: String::new(),
-            zero_trust_gateway: false,
-            route_block: String::new(),
-            route_direct: String::new(),
-            routes_file: String::new(),
-        }
-    }
-}
-
-const STORE_FILE: &str = "profile.json";
-const STORE_KEY: &str = "last_successful_profile";
-
-/// Loads the last profile that reached `Connected`, or the hardcoded default
-/// on first run. Only ever written by `save()` at the moment a connection
-/// actually succeeds (see aether/mod.rs) — never on a mere attempt, so a bad
-/// guess can't poison future one-click connects.
-pub fn load(app: &tauri::AppHandle) -> ConnectionProfile {
-    use tauri_plugin_store::StoreExt;
-    app.store(STORE_FILE)
-        .ok()
-        .and_then(|s| s.get(STORE_KEY))
-        .and_then(|v| serde_json::from_value(v).ok())
-        .unwrap_or_default()
-}
-
-pub fn save(app: &tauri::AppHandle, profile: &ConnectionProfile) {
-    use tauri_plugin_store::StoreExt;
-    if let Ok(store) = app.store(STORE_FILE) {
-        // A successful connection profile is useful to remember, but Access
-        // credentials are not. Leave them in process memory only; the next
-        // app launch will ask for them again rather than writing a JWT,
-        // service secret or email address into profile.json.
-        let mut persisted = profile.clone();
-        persisted.access_email.clear();
-        persisted.access_client_id.clear();
-        persisted.access_client_secret.clear();
-        persisted.access_token.clear();
-        if let Ok(value) = serde_json::to_value(persisted) {
-            store.set(STORE_KEY, value);
-            let _ = store.save();
-        }
     }
 }

--- a/src-tauri/src/aether/status.rs
+++ b/src-tauri/src/aether/status.rs
@@ -5,7 +5,8 @@ use std::time::Duration;
 pub const DEFAULT_SOCKS_ADDR: &str = "127.0.0.1:1819";
 
 pub fn parse_bind_address(addr: &str) -> SocketAddr {
-    addr.parse().unwrap_or_else(|_| DEFAULT_SOCKS_ADDR.parse().unwrap())
+    addr.parse()
+        .unwrap_or_else(|_| DEFAULT_SOCKS_ADDR.parse().unwrap())
 }
 
 /// When Aether listens on 0.0.0.0, we probe 127.0.0.1 instead.
@@ -60,8 +61,11 @@ pub const GRACEFUL_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 /// drop (a flaky relay, a momentary network hiccup) is more likely to have
 /// cleared given a moment, and to avoid hammering the same dead endpoint.
 pub const MAX_AUTO_RETRIES: u32 = 3;
-pub const RETRY_BACKOFF: [Duration; MAX_AUTO_RETRIES as usize] =
-    [Duration::from_secs(2), Duration::from_secs(5), Duration::from_secs(10)];
+pub const RETRY_BACKOFF: [Duration; MAX_AUTO_RETRIES as usize] = [
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(10),
+];
 
 #[cfg(test)]
 mod tests {
@@ -71,11 +75,26 @@ mod tests {
 
     #[test]
     fn parse_valid_and_invalid() {
-        assert_eq!(parse_bind_address("127.0.0.1:1919"), "127.0.0.1:1919".parse().unwrap());
-        assert_eq!(parse_bind_address("0.0.0.0:1819"), "0.0.0.0:1819".parse().unwrap());
-        assert_eq!(parse_bind_address("0.0.0.0:9999"), "0.0.0.0:9999".parse().unwrap());
-        assert_eq!(parse_bind_address("127.0.0.1:"), DEFAULT_SOCKS_ADDR.parse().unwrap());
-        assert_eq!(parse_bind_address("not-an-addr"), DEFAULT_SOCKS_ADDR.parse().unwrap());
+        assert_eq!(
+            parse_bind_address("127.0.0.1:1919"),
+            "127.0.0.1:1919".parse().unwrap()
+        );
+        assert_eq!(
+            parse_bind_address("0.0.0.0:1819"),
+            "0.0.0.0:1819".parse().unwrap()
+        );
+        assert_eq!(
+            parse_bind_address("0.0.0.0:9999"),
+            "0.0.0.0:9999".parse().unwrap()
+        );
+        assert_eq!(
+            parse_bind_address("127.0.0.1:"),
+            DEFAULT_SOCKS_ADDR.parse().unwrap()
+        );
+        assert_eq!(
+            parse_bind_address("not-an-addr"),
+            DEFAULT_SOCKS_ADDR.parse().unwrap()
+        );
     }
 
     #[test]
@@ -90,9 +109,13 @@ mod tests {
     fn port_is_live_detects_listener() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        thread::spawn(move || { let _ = listener.accept(); });
+        thread::spawn(move || {
+            let _ = listener.accept();
+        });
         assert!(port_is_live(&addr));
-        let dead: SocketAddr = format!("127.0.0.1:{}", addr.port().wrapping_add(1).max(20000)).parse().unwrap();
+        let dead: SocketAddr = format!("127.0.0.1:{}", addr.port().wrapping_add(1).max(20000))
+            .parse()
+            .unwrap();
         if TcpStream::connect_timeout(&dead, Duration::from_millis(50)).is_err() {
             assert!(!port_is_live(&dead));
         }
@@ -102,9 +125,14 @@ mod tests {
     fn port_is_live_probes_loopback_when_bound_any() {
         let listener = TcpListener::bind("0.0.0.0:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        thread::spawn(move || { let _ = listener.accept(); });
+        thread::spawn(move || {
+            let _ = listener.accept();
+        });
         let any = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), addr.port());
-        assert!(port_is_live(&any), "should probe 127.0.0.1 when listen is 0.0.0.0");
+        assert!(
+            port_is_live(&any),
+            "should probe 127.0.0.1 when listen is 0.0.0.0"
+        );
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -22,10 +22,19 @@ pub enum ConnectionState {
     /// `connected_at_ms` is an absolute UNIX-epoch timestamp (ms) rather than
     /// a pre-computed elapsed duration, so the frontend can render a live-
     /// updating session timer without needing another event from the backend.
-    Connected { socks_addr: String, connected_at_ms: u64 },
-    Reconnecting { attempt: u32, max_attempts: u32 },
+    Connected {
+        socks_addr: String,
+        connected_at_ms: u64,
+    },
+    Reconnecting {
+        attempt: u32,
+        max_attempts: u32,
+    },
     Disconnecting,
-    Error { message: String, phase: String },
+    Error {
+        message: String,
+        phase: String,
+    },
 }
 
 pub struct AppState {


### PR DESCRIPTION
## Why

CONTRIBUTING tells every contributor to run this before opening a PR:

```sh
cd src-tauri && cargo fmt --check && cargo clippy --all-targets -- -D warnings
```

Both halves fail on `main` today, so the instruction can't actually be followed, and every PR starts out looking non-compliant for reasons that have nothing to do with it.

## What

- **rustfmt** — `state.rs` and `status.rs` were unformatted. Pure formatting, no logic touched.
- **clippy `items_after_test_module`** — `profiles.rs` had `mod tests` sitting in the middle of the file, ahead of `impl Default`, the store constants and `load`/`save`. Moved to the end; the tests themselves are unchanged.
- **clippy `field_reassign_with_default`** — four bind-address tests built a default and then reassigned one field. Rewritten with struct-update syntax, matching how the newer tests in the same module already do it.

## Verification

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both pass. `cargo test` still 20/20. No behaviour change.

This is the base of a four-PR stack; the other three sit on top of it so they inherit a green gate.
